### PR TITLE
Shortwave TextDisplay fixes

### DIFF
--- a/plugins/shortwave-paper/src/main/java/world/edenmc/shortwave/ShortwavePlugin.java
+++ b/plugins/shortwave-paper/src/main/java/world/edenmc/shortwave/ShortwavePlugin.java
@@ -1,5 +1,6 @@
 package world.edenmc.shortwave;
 
+import world.edenmc.shortwave.listeners.ChunkUnloadCleanupListener;
 import world.edenmc.shortwave.listeners.InteractionListener;
 import world.edenmc.shortwave.listeners.OxidationListener;
 import world.edenmc.shortwave.managers.ConfigManager;
@@ -68,7 +69,7 @@ public class ShortwavePlugin extends JavaPlugin {
         // Register listeners
         getServer().getPluginManager().registerEvents(new InteractionListener(this), this);
         getServer().getPluginManager().registerEvents(new OxidationListener(this), this);
-        getServer().getPluginManager().registerEvents(new ClickableInventoryListener(), this);
+        getServer().getPluginManager().registerEvents(new ChunkUnloadCleanupListener(this), this);
 
         int autoSaveTicks = configManager.getAutoSaveInterval();
         Bukkit.getScheduler().runTaskTimer(this, () -> {

--- a/plugins/shortwave-paper/src/main/java/world/edenmc/shortwave/listeners/ChunkUnloadCleanupListener.java
+++ b/plugins/shortwave-paper/src/main/java/world/edenmc/shortwave/listeners/ChunkUnloadCleanupListener.java
@@ -1,0 +1,30 @@
+package world.edenmc.shortwave.listeners;
+
+import world.edenmc.shortwave.ShortwavePlugin;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.TextDisplay;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.EntitiesUnloadEvent;
+import org.bukkit.persistence.PersistentDataType;
+
+public class ChunkUnloadCleanupListener implements Listener {
+
+    private final ShortwavePlugin plugin;
+
+    public ChunkUnloadCleanupListener(ShortwavePlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onEntitiesUnload(EntitiesUnloadEvent event) {
+        NamespacedKey broadcastKey = plugin.getBroadcastKey();
+        for (Entity entity : event.getEntities()) {
+            if (entity instanceof TextDisplay && entity.getPersistentDataContainer().has(broadcastKey, PersistentDataType.BYTE)) {
+                entity.remove();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This removes the TextDisplay on Chunk / Entity-unloading, therefore removing the entity completely and players wont have an issue anymore when re-entering that chunk that the text gets duplicated.

The hashmap solution from a previous PR isn't needed at all for this, so if its sole purpose was to prevent the duplicates it can be scrapped.