### PR TITLE
Show days remaining on pearls

### DIFF
--- a/plugins/exilepearl-paper/build.gradle.kts
+++ b/plugins/exilepearl-paper/build.gradle.kts
@@ -19,4 +19,13 @@ dependencies {
     compileOnly(project(":plugins:randomspawn-paper"))
 
     compileOnly(files("../../ansible/src/paper-plugins/BreweryX-3.6.0.jar"))
+
+    testImplementation(libs.bundles.junit)
+    testImplementation(project(":plugins:civmodcore-paper"))
+    testImplementation(project(":plugins:combattagplus-paper"))
+    testImplementation("org.mockito:mockito-core:5.11.0")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
@@ -84,6 +84,15 @@ final class CoreLoreGenerator implements LoreProvider {
         lore.add(parse(""));
 
         lore.add(parse("<a>Health: <n>%s/%s", health, config.getPearlHealthMaxValue()));
+        String unit = config.getPearlHealthDecayHumanInterval();
+        int decayPerHumanInterval = PearlDecayMath.decayPerHumanInterval(
+            config.getPearlHealthDecayHumanIntervalMin(),
+            config.getPearlHealthDecayIntervalMin(),
+            config.getPearlHealthDecayAmount());
+        int intervalsRemaining = PearlDecayMath.intervalsRemaining(health, decayPerHumanInterval);
+        if (intervalsRemaining > 0 && pearl.isActive()) {
+            lore.add(parse("<a>Time remaining: <n>%d %s", intervalsRemaining, unit));
+        }
         Set<RepairMaterial> repair = config.getRepairMaterials(pearl.getPearlType());
         if (repair != null) {
             for (RepairMaterial rep : repair) {
@@ -92,9 +101,8 @@ final class CoreLoreGenerator implements LoreProvider {
                 if (rep.getStack().hasItemMeta() && rep.getStack().getItemMeta().hasDisplayName()) {
                     item = rep.getStack().getItemMeta().getDisplayName();
                 }
-                int damagesPerHumanInterval = (config.getPearlHealthDecayHumanIntervalMin() / config.getPearlHealthDecayIntervalMin()) * config.getPearlHealthDecayAmount(); // intervals in a human interval * damage per
-                int repairsPerHumanInterval = (int) Math.ceil(damagesPerHumanInterval / amountPerItem);
-                lore.add(parse("<a>Cost per %s using %s:<n> %s", config.getPearlHealthDecayHumanInterval(), item, Integer.toString(repairsPerHumanInterval)));
+                int repairsPerHumanInterval = (int) Math.ceil(decayPerHumanInterval / amountPerItem);
+                lore.add(parse("<a>Cost per %s using %s:<n> %s", unit, item, Integer.toString(repairsPerHumanInterval)));
             }
         }
 

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/PearlDecayMath.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/PearlDecayMath.java
@@ -1,0 +1,20 @@
+package com.devotedmc.ExilePearl.core;
+
+final class PearlDecayMath {
+
+    private PearlDecayMath() {}
+
+    static int decayPerHumanInterval(int humanIntervalMin, int decayIntervalMin, int decayAmount) {
+        if (decayIntervalMin <= 0) {
+            return 0;
+        }
+        return (humanIntervalMin / decayIntervalMin) * decayAmount;
+    }
+
+    static int intervalsRemaining(int health, int decayPerHumanInterval) {
+        if (decayPerHumanInterval <= 0 || health <= 0) {
+            return 0;
+        }
+        return (int) Math.ceil((double) health / decayPerHumanInterval);
+    }
+}

--- a/plugins/exilepearl-paper/src/test/java/com/devotedmc/ExilePearl/core/CoreLoreGeneratorTest.java
+++ b/plugins/exilepearl-paper/src/test/java/com/devotedmc/ExilePearl/core/CoreLoreGeneratorTest.java
@@ -1,0 +1,150 @@
+package com.devotedmc.ExilePearl.core;
+
+import com.devotedmc.ExilePearl.ExilePearl;
+import com.devotedmc.ExilePearl.ExilePearlApi;
+import com.devotedmc.ExilePearl.ExilePearlPlugin;
+import com.devotedmc.ExilePearl.PearlType;
+import com.devotedmc.ExilePearl.RepairMaterial;
+import com.devotedmc.ExilePearl.config.PearlConfig;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+class CoreLoreGeneratorTest {
+
+    private PearlConfig config;
+    private ExilePearl pearl;
+    private CoreLoreGenerator generator;
+    private MockedStatic<ExilePearlPlugin> pluginStatic;
+
+    @BeforeEach
+    void setUp() {
+        config = Mockito.mock(PearlConfig.class);
+        Mockito.when(config.getPearlHealthMaxValue()).thenReturn(1000);
+        Mockito.when(config.getPearlHealthDecayHumanIntervalMin()).thenReturn(1440); // 1 day
+        Mockito.when(config.getPearlHealthDecayIntervalMin()).thenReturn(60);        // hourly tick
+        Mockito.when(config.getPearlHealthDecayAmount()).thenReturn(1);              // -> 24/day
+        Mockito.when(config.getPearlHealthDecayHumanInterval()).thenReturn("day");
+        Mockito.when(config.getRepairMaterials(Mockito.any())).thenReturn(null);
+        Mockito.when(config.getDefaultPearlType()).thenReturn(PearlType.EXILE);
+        Mockito.when(config.getUpgradeMaterials()).thenReturn(null);
+
+        pearl = Mockito.mock(ExilePearl.class);
+        Mockito.when(pearl.getItemName()).thenReturn("Exile Pearl");
+        Mockito.when(pearl.getPlayerName()).thenReturn("TestPlayer");
+        Mockito.when(pearl.getPearlId()).thenReturn(12345);
+        Mockito.when(pearl.getPearledOn()).thenReturn(new Date(0));
+        Mockito.when(pearl.getKillerName()).thenReturn("KillerPlayer");
+        Mockito.when(pearl.getPlayerId()).thenReturn(UUID.randomUUID());
+        Mockito.when(pearl.getPearlType()).thenReturn(PearlType.EXILE);
+        Mockito.when(pearl.getHealth()).thenReturn(240); // exactly 10 days at 24/day
+        Mockito.when(pearl.isActive()).thenReturn(true);
+        Mockito.when(pearl.getLongTimeMultiplier()).thenReturn(1.0);
+
+        ExilePearlApi api = Mockito.mock(ExilePearlApi.class);
+        Mockito.when(api.isBanStickEnabled()).thenReturn(false);
+        pluginStatic = Mockito.mockStatic(ExilePearlPlugin.class);
+        pluginStatic.when(ExilePearlPlugin::getApi).thenReturn(api);
+
+        generator = new CoreLoreGenerator(config, null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        pluginStatic.close();
+    }
+
+    @Test
+    void generateLore_includesTimeRemainingForActivePearl() {
+        List<String> lore = generator.generateLore(pearl);
+        String timeRemaining = findLine(lore, "Time remaining:");
+        Assertions.assertNotNull(timeRemaining, "Expected a 'Time remaining' line, got: " + lore);
+        Assertions.assertTrue(timeRemaining.contains("10"), "Expected 10 days for health=240 / 24-per-day, got: " + timeRemaining);
+        Assertions.assertTrue(timeRemaining.contains("day"), "Expected unit 'day' in: " + timeRemaining);
+    }
+
+    @Test
+    void generateLore_omitsTimeRemainingForInactivePearl() {
+        Mockito.when(pearl.isActive()).thenReturn(false);
+        List<String> lore = generator.generateLore(pearl);
+        Assertions.assertNull(findLine(lore, "Time remaining:"),
+            "Inactive pearl should not show time remaining (already shows 'suspended due to Inactivity'); got: " + lore);
+    }
+
+    @Test
+    void generateLore_omitsTimeRemainingWhenHealthIsZero() {
+        Mockito.when(pearl.getHealth()).thenReturn(0);
+        List<String> lore = generator.generateLore(pearl);
+        Assertions.assertNull(findLine(lore, "Time remaining:"), "Zero health should hide time remaining; got: " + lore);
+    }
+
+    @Test
+    void generateLore_omitsTimeRemainingWhenDecayDisabled() {
+        Mockito.when(config.getPearlHealthDecayAmount()).thenReturn(0);
+        List<String> lore = generator.generateLore(pearl);
+        Assertions.assertNull(findLine(lore, "Time remaining:"), "Decay disabled should hide time remaining; got: " + lore);
+    }
+
+    @Test
+    void generateLore_timeRemainingRoundsUpForPartialInterval() {
+        Mockito.when(pearl.getHealth()).thenReturn(241); // 24*10 + 1
+        List<String> lore = generator.generateLore(pearl);
+        String timeRemaining = findLine(lore, "Time remaining:");
+        Assertions.assertNotNull(timeRemaining);
+        Assertions.assertTrue(timeRemaining.contains("11"), "241 health at 24/day should round up to 11 days, got: " + timeRemaining);
+    }
+
+    @Test
+    void generateLore_timeRemainingUsesConfiguredUnit() {
+        Mockito.when(config.getPearlHealthDecayHumanInterval()).thenReturn("week");
+        List<String> lore = generator.generateLore(pearl);
+        String timeRemaining = findLine(lore, "Time remaining:");
+        Assertions.assertNotNull(timeRemaining);
+        Assertions.assertTrue(timeRemaining.contains("week"), "Configured unit 'week' should be used, got: " + timeRemaining);
+    }
+
+    @Test
+    void generateLore_timeRemainingAppearsRightAfterHealth() {
+        List<String> lore = generator.generateLore(pearl);
+        int healthIdx = indexOfContaining(lore, "Health:");
+        int timeIdx = indexOfContaining(lore, "Time remaining:");
+        Assertions.assertTrue(healthIdx >= 0 && timeIdx == healthIdx + 1,
+            "Time remaining should be immediately after Health; got lore: " + lore);
+    }
+
+    @Test
+    void generateLore_doesNotMutateConfiguredUnitForRepairLine() {
+        Mockito.when(config.getPearlHealthDecayHumanInterval()).thenReturn("day");
+        Mockito.when(pearl.getHealth()).thenReturn(24); // 1 interval
+        List<String> lore = generator.generateLore(pearl);
+        String timeRemaining = findLine(lore, "Time remaining:");
+        Assertions.assertNotNull(timeRemaining);
+        // Regression guard: no English-plural "s" injected, matches existing repair-line style
+        Assertions.assertFalse(timeRemaining.contains("days"),
+            "Lore must not append plural 's' to configured unit; got: " + timeRemaining);
+    }
+
+    private static String findLine(List<String> lore, String marker) {
+        for (String line : lore) {
+            if (line.contains(marker)) {
+                return line;
+            }
+        }
+        return null;
+    }
+
+    private static int indexOfContaining(List<String> lore, String marker) {
+        for (int i = 0; i < lore.size(); i++) {
+            if (lore.get(i).contains(marker)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/plugins/exilepearl-paper/src/test/java/com/devotedmc/ExilePearl/core/PearlDecayMathTest.java
+++ b/plugins/exilepearl-paper/src/test/java/com/devotedmc/ExilePearl/core/PearlDecayMathTest.java
@@ -1,0 +1,53 @@
+package com.devotedmc.ExilePearl.core;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PearlDecayMathTest {
+
+    @Test
+    void decayPerHumanInterval_typicalDayConfig() {
+        // 1440 min/day, decay every 60 min, 1 health per tick -> 24 health/day
+        Assertions.assertEquals(24, PearlDecayMath.decayPerHumanInterval(1440, 60, 1));
+    }
+
+    @Test
+    void decayPerHumanInterval_zeroDecayInterval_returnsZero() {
+        Assertions.assertEquals(0, PearlDecayMath.decayPerHumanInterval(1440, 0, 1));
+    }
+
+    @Test
+    void decayPerHumanInterval_zeroDecayAmount_returnsZero() {
+        Assertions.assertEquals(0, PearlDecayMath.decayPerHumanInterval(1440, 60, 0));
+    }
+
+    @Test
+    void intervalsRemaining_exactlyDivisible() {
+        Assertions.assertEquals(10, PearlDecayMath.intervalsRemaining(240, 24));
+    }
+
+    @Test
+    void intervalsRemaining_roundsUp() {
+        Assertions.assertEquals(11, PearlDecayMath.intervalsRemaining(241, 24));
+    }
+
+    @Test
+    void intervalsRemaining_partialIntervalRoundsUpToOne() {
+        Assertions.assertEquals(1, PearlDecayMath.intervalsRemaining(1, 24));
+    }
+
+    @Test
+    void intervalsRemaining_zeroHealth_returnsZero() {
+        Assertions.assertEquals(0, PearlDecayMath.intervalsRemaining(0, 24));
+    }
+
+    @Test
+    void intervalsRemaining_negativeHealth_returnsZero() {
+        Assertions.assertEquals(0, PearlDecayMath.intervalsRemaining(-5, 24));
+    }
+
+    @Test
+    void intervalsRemaining_decayDisabled_returnsZero() {
+        Assertions.assertEquals(0, PearlDecayMath.intervalsRemaining(100, 0));
+    }
+}


### PR DESCRIPTION
Add a "Time remaining: N <unit>" line to pearl item lore directly
beneath the existing health line. The interval count is computed
from the configured decay rate, rounded up, and uses the same
admin-configured unit string as the existing repair-cost lines,
so operators control plurality and translation in one place.

The line is hidden when the pearl is inactive (decay is already
flagged separately as "suspended due to Inactivity"), when health
has reached zero, or when decay is disabled in config.

While here, hoist the shared decay-per-interval and unit values
so the existing repair-cost loop reuses them instead of
recomputing per material.

---

Ported from [CivMC/Civ#917](https://github.com/CivMC/Civ/pull/917), which was closed without resolution.

The tests in this PR depend on JUnit infrastructure that is currently broken in the parent. If [eden-fix-test-suite](https://github.com/EdenMinecraft/Civ/pulls) lands first, the tests here will execute on CI. Otherwise they sit dormant alongside the existing tests in the suite.

**LLM disclosure:** Code authored with Claude Opus 4.7 assistance.