### PR TITLE
Fix swapped server/world in insertData overloads

### DIFF
--- a/plugins/civspy-api/build.gradle.kts
+++ b/plugins/civspy-api/build.gradle.kts
@@ -3,4 +3,7 @@ version = "2.0.1"
 dependencies {
     implementation("com.zaxxer:HikariCP:3.4.2")
     implementation("org.postgresql:postgresql:42.3.5")
+
+    testImplementation(libs.bundles.junit)
+    testImplementation("org.mockito:mockito-core:5.11.0")
 }

--- a/plugins/civspy-api/src/main/java/com/programmerdan/minecraft/civspy/database/Database.java
+++ b/plugins/civspy-api/src/main/java/com/programmerdan/minecraft/civspy/database/Database.java
@@ -228,40 +228,40 @@ public class Database {
     }
 
     public int insertData(String key, String server, String world, Integer chunk_x, Integer chunk_z) {
-        return insertData(key, world, server, chunk_x, chunk_z, null, null, null, null, null);
+        return insertData(key, server, world, chunk_x, chunk_z, null, null, null, null, null);
     }
 
     public int insertData(String key, String server, String world, Integer chunk_x, Integer chunk_z, String value) {
-        return insertData(key, world, server, chunk_x, chunk_z, null, value, null, null, null);
+        return insertData(key, server, world, chunk_x, chunk_z, null, value, null, null, null);
     }
 
     public int insertData(String key, String server, String world, Integer chunk_x, Integer chunk_z, Number value) {
-        return insertData(key, world, server, chunk_x, chunk_z, null, null, value, null, null);
+        return insertData(key, server, world, chunk_x, chunk_z, null, null, value, null, null);
     }
 
     public int insertData(String key, String server, String world, Integer chunk_x, Integer chunk_z, String sValue, Number nValue) {
-        return insertData(key, world, server, chunk_x, chunk_z, null, sValue, nValue, null, null);
+        return insertData(key, server, world, chunk_x, chunk_z, null, sValue, nValue, null, null);
     }
 
     public int insertData(String key, String server, String world, Integer chunk_x, Integer chunk_z, String sValue, Number nValue,
                           Long time, Connection connection) {
-        return insertData(key, world, server, chunk_x, chunk_z, null, sValue, nValue, time, connection);
+        return insertData(key, server, world, chunk_x, chunk_z, null, sValue, nValue, time, connection);
     }
 
     public int insertData(String key, String server, String world, Integer chunk_x, Integer chunk_z, UUID uuid) {
-        return insertData(key, world, server, chunk_x, chunk_z, uuid, null, null, null, null);
+        return insertData(key, server, world, chunk_x, chunk_z, uuid, null, null, null, null);
     }
 
     public int insertData(String key, String server, String world, Integer chunk_x, Integer chunk_z, UUID uuid, String value) {
-        return insertData(key, world, server, chunk_x, chunk_z, uuid, value, null, null, null);
+        return insertData(key, server, world, chunk_x, chunk_z, uuid, value, null, null, null);
     }
 
     public int insertData(String key, String server, String world, Integer chunk_x, Integer chunk_z, UUID uuid, Number value) {
-        return insertData(key, world, server, chunk_x, chunk_z, uuid, null, value, null, null);
+        return insertData(key, server, world, chunk_x, chunk_z, uuid, null, value, null, null);
     }
 
     public int insertData(String key, String server, String world, Integer chunk_x, Integer chunk_z, UUID uuid, String sValue, Number nValue) {
-        return insertData(key, world, server, chunk_x, chunk_z, uuid, sValue, nValue, null, null);
+        return insertData(key, server, world, chunk_x, chunk_z, uuid, sValue, nValue, null, null);
     }
 
     /**

--- a/plugins/civspy-api/src/test/java/com/programmerdan/minecraft/civspy/database/DatabaseInsertDataTest.java
+++ b/plugins/civspy-api/src/test/java/com/programmerdan/minecraft/civspy/database/DatabaseInsertDataTest.java
@@ -1,0 +1,53 @@
+package com.programmerdan.minecraft.civspy.database;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+public class DatabaseInsertDataTest {
+
+    /**
+     * INSERT_STRING binds (stat_time, stat_key, string_value, server, world, ...), so with a string value
+     * present the server column is parameter 4 and the world column is parameter 5.
+     */
+    private static final int SERVER_INDEX = 4;
+    private static final int WORLD_INDEX = 5;
+
+    @Test
+    public void convenienceOverloadBindsServerAndWorldToCorrectColumns() throws Exception {
+        Connection connection = Mockito.mock(Connection.class);
+        PreparedStatement statement = Mockito.mock(PreparedStatement.class);
+        when(connection.prepareStatement(Database.INSERT_STRING)).thenReturn(statement);
+        when(statement.executeUpdate()).thenReturn(1);
+
+        Database db = new Database(Logger.getLogger("test"), null, null, null, 0, null, 0, 0L, 0L, 0L);
+
+        db.insertData("test.key", "the-server", "the-world", 7, 9, "string-value", null, 123L, connection);
+
+        ArgumentCaptor<Integer> indexCaptor = ArgumentCaptor.forClass(Integer.class);
+        ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
+        verify(statement, atLeastOnce()).setString(indexCaptor.capture(), valueCaptor.capture());
+
+        Map<Integer, String> boundStrings = new HashMap<>();
+        List<Integer> indices = indexCaptor.getAllValues();
+        List<String> values = valueCaptor.getAllValues();
+        for (int i = 0; i < indices.size(); i++) {
+            boundStrings.put(indices.get(i), values.get(i));
+        }
+
+        assertEquals("the-server", boundStrings.get(SERVER_INDEX), "server must bind to the server column");
+        assertEquals("the-world", boundStrings.get(WORLD_INDEX), "world must bind to the world column");
+    }
+}


### PR DESCRIPTION
## Problem
The convenience `insertData(..., String server, String world, ...)` overloads delegated to the canonical method as `(..., world, server, ...)` — transposed. Callers using the documented `(server, world)` order had the two columns stored swapped.

## Fix
Pass the arguments in the correct order in all 9 affected overloads.

## Safety
Grepped the whole repo for callers of these server/world overloads: **none**. The live stats pipeline uses `batchData`, which already bound the columns correctly, and the only external `insertData` callers (civspy-bungee) use the `UUID`/`Number` overloads. Nothing relied on the broken order — pure latent-correctness fix.

## Test
Added `DatabaseInsertDataTest` (mocked `Connection`/`PreparedStatement`) asserting `server` and `world` each bind to their own column. Negative control verified.
