### PR TITLE
Persist applied migration id in Migrator

### DIFF
--- a/libraries/name-api/build.gradle.kts
+++ b/libraries/name-api/build.gradle.kts
@@ -10,4 +10,11 @@ dependencies {
     api(libs.configurate.yaml)
     api("org.mariadb.jdbc:mariadb-java-client:3.5.6")
     implementation(libs.slf4j.api)
+
+    testImplementation(libs.bundles.junit)
+    testImplementation("org.mockito:mockito-core:5.11.0")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/libraries/name-api/src/main/java/net/civmc/nameapi/Migrator.java
+++ b/libraries/name-api/src/main/java/net/civmc/nameapi/Migrator.java
@@ -5,6 +5,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -32,33 +33,40 @@ public class Migrator {
 
     public void migrate(Connection connection) throws SQLException {
         connection.setAutoCommit(false);
-        connection.createStatement().executeUpdate("CREATE TABLE IF NOT EXISTS migrations (" +
-            "namespace VARCHAR(64) PRIMARY KEY," +
-            "id INT NOT NULL)");
+        try (Statement createTable = connection.createStatement()) {
+            createTable.executeUpdate("CREATE TABLE IF NOT EXISTS migrations (" +
+                "namespace VARCHAR(64) PRIMARY KEY," +
+                "id INT NOT NULL)");
+        }
 
         for (Map.Entry<String, NavigableMap<Integer, String[]>> entry : migrations.entrySet()) {
-            PreparedStatement getMigrationId = connection.prepareStatement("SELECT id FROM migrations WHERE namespace = ? FOR UPDATE");
-            getMigrationId.setString(1, entry.getKey());
-            ResultSet resultSet = getMigrationId.executeQuery();
             int minId;
-            if (resultSet.next()) {
-                minId = resultSet.getInt("id");
-            } else {
-                minId = -1;
+            try (PreparedStatement getMigrationId = connection.prepareStatement("SELECT id FROM migrations WHERE namespace = ? FOR UPDATE")) {
+                getMigrationId.setString(1, entry.getKey());
+                ResultSet resultSet = getMigrationId.executeQuery();
+                if (resultSet.next()) {
+                    minId = resultSet.getInt("id");
+                } else {
+                    minId = -1;
+                }
             }
 
             NavigableMap<Integer, String[]> value = entry.getValue().tailMap(minId, false);
             int maxId = entry.getValue().lastKey();
             for (String[] migration : value.sequencedValues()) {
                 for (String sql : migration) {
-                    connection.createStatement().executeUpdate(sql);
+                    try (Statement statement = connection.createStatement()) {
+                        statement.executeUpdate(sql);
+                    }
                 }
             }
 
             if (maxId != minId) {
-                PreparedStatement setMigrationId = connection.prepareStatement("REPLACE INTO migrations (namespace, id) VALUES (?, ?)");
-                setMigrationId.setString(1, entry.getKey());
-                setMigrationId.setInt(2, maxId);
+                try (PreparedStatement setMigrationId = connection.prepareStatement("REPLACE INTO migrations (namespace, id) VALUES (?, ?)")) {
+                    setMigrationId.setString(1, entry.getKey());
+                    setMigrationId.setInt(2, maxId);
+                    setMigrationId.executeUpdate();
+                }
             }
         }
         connection.setAutoCommit(true);

--- a/libraries/name-api/src/test/java/net/civmc/nameapi/MigratorTest.java
+++ b/libraries/name-api/src/test/java/net/civmc/nameapi/MigratorTest.java
@@ -1,0 +1,41 @@
+package net.civmc.nameapi;
+
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MigratorTest {
+
+    @Test
+    void persistsAppliedMigrationId() throws SQLException {
+        Connection connection = mock(Connection.class);
+        when(connection.createStatement()).thenReturn(mock(Statement.class));
+
+        ResultSet emptyResult = mock(ResultSet.class);
+        when(emptyResult.next()).thenReturn(false);
+
+        PreparedStatement selectStatement = mock(PreparedStatement.class);
+        when(selectStatement.executeQuery()).thenReturn(emptyResult);
+        when(connection.prepareStatement("SELECT id FROM migrations WHERE namespace = ? FOR UPDATE"))
+            .thenReturn(selectStatement);
+
+        PreparedStatement replaceStatement = mock(PreparedStatement.class);
+        when(connection.prepareStatement("REPLACE INTO migrations (namespace, id) VALUES (?, ?)"))
+            .thenReturn(replaceStatement);
+
+        Migrator migrator = new Migrator();
+        migrator.registerMigration("test", 0, "SELECT 1");
+        migrator.migrate(connection);
+
+        verify(replaceStatement).setInt(2, 0);
+        verify(replaceStatement).executeUpdate();
+    }
+}


### PR DESCRIPTION
## Problem
`Migrator.migrate` prepared the `REPLACE INTO migrations` statement and bound its parameters but never executed it. The applied id was never stored, so **every migration re-ran on each boot**.

## Fix
Execute the statement, and close the prepared/created statements with try-with-resources (also fixes the statement leaks).

## Test
Wired JUnit 5 + Mockito into the previously test-less `name-api` library and added `MigratorTest` verifying the `REPLACE` statement's `setInt(2, id)` and `executeUpdate()` are invoked.
