### PR TITLE
Show rail destination on the sidebar scoreboard

### DIFF
--- a/plugins/railswitch-paper/build.gradle.kts
+++ b/plugins/railswitch-paper/build.gradle.kts
@@ -12,4 +12,7 @@ dependencies {
     compileOnly(project(":plugins:civmodcore-paper"))
     compileOnly(project(":plugins:namelayer-paper"))
     compileOnly(project(":plugins:citadel-paper"))
+
+    testImplementation(libs.bundles.junit)
+    testImplementation(project(":plugins:civmodcore-paper"))
 }

--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/RailSwitchPlugin.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/RailSwitchPlugin.java
@@ -3,6 +3,7 @@ package sh.okx.railswitch;
 import org.bukkit.event.Listener;
 import sh.okx.railswitch.commands.DestinationCommand;
 import sh.okx.railswitch.glue.CitadelGlue;
+import sh.okx.railswitch.settings.DestinationDisplayListener;
 import sh.okx.railswitch.settings.SettingsManager;
 import sh.okx.railswitch.switches.SwitchListener;
 import vg.civcraft.mc.civmodcore.ACivMod;
@@ -23,6 +24,7 @@ public final class RailSwitchPlugin extends ACivMod implements Listener {
         registerListener(new CitadelGlue(this));
         registerListener(new SwitchListener());
         registerListener(new DestSignListener());
+        registerListener(new DestinationDisplayListener());
         commandManager = new CommandManager(this);
         commandManager.init();
         commandManager.registerCommand(new DestinationCommand());

--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/DestinationDisplayListener.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/DestinationDisplayListener.java
@@ -1,0 +1,18 @@
+package sh.okx.railswitch.settings;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+/**
+ * Restores a player's destination sidebar line when they log in.
+ */
+public final class DestinationDisplayListener implements Listener {
+
+    // NORMAL runs after civmodcore's ScoreBoardListener resets the scoreboard at LOWEST on join.
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onJoin(PlayerJoinEvent event) {
+        SettingsManager.restoreDestinationDisplay(event.getPlayer());
+    }
+}

--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/DestinationScoreboard.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/DestinationScoreboard.java
@@ -1,0 +1,46 @@
+package sh.okx.railswitch.settings;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import vg.civcraft.mc.civmodcore.players.scoreboard.side.CivScoreBoard;
+import vg.civcraft.mc.civmodcore.players.scoreboard.side.ScoreBoardAPI;
+
+/**
+ * Shows a player's rail destination on the civmodcore sidebar scoreboard.
+ */
+public final class DestinationScoreboard {
+
+    private static final String BOARD_KEY = "railSwitchDest";
+
+    private final CivScoreBoard board;
+
+    public DestinationScoreboard() {
+        this.board = ScoreBoardAPI.createBoard(BOARD_KEY);
+    }
+
+    /**
+     * Shows the destination line for the player, or hides it when there is no destination.
+     */
+    public void update(Player player, String destination) {
+        if (player == null) {
+            return;
+        }
+        String line = render(destination);
+        if (line == null) {
+            board.hide(player);
+        } else {
+            board.set(player, line);
+        }
+    }
+
+    public void delete() {
+        ScoreBoardAPI.deleteBoard(board);
+    }
+
+    static String render(String destination) {
+        if (destination == null || destination.isBlank()) {
+            return null;
+        }
+        return ChatColor.GOLD + "/dest: " + ChatColor.LIGHT_PURPLE + destination;
+    }
+}

--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/DestinationScoreboard.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/DestinationScoreboard.java
@@ -12,6 +12,11 @@ public final class DestinationScoreboard {
 
     private static final String BOARD_KEY = "railSwitchDest";
 
+    // CivScoreBoard truncates the displayed line at 40 chars but caches the full string,
+    // so an over-long line leaves a stale entry that never clears. The "/dest: " label plus
+    // colour codes is 11 chars, leaving 29 for the value.
+    private static final int MAX_DESTINATION_LENGTH = 29;
+
     private final CivScoreBoard board;
 
     public DestinationScoreboard() {
@@ -41,6 +46,9 @@ public final class DestinationScoreboard {
         if (destination == null || destination.isBlank()) {
             return null;
         }
-        return ChatColor.GOLD + "/dest: " + ChatColor.LIGHT_PURPLE + destination;
+        String value = destination.length() > MAX_DESTINATION_LENGTH
+            ? destination.substring(0, MAX_DESTINATION_LENGTH)
+            : destination;
+        return ChatColor.GOLD + "/dest: " + ChatColor.LIGHT_PURPLE + value;
     }
 }

--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/SettingsManager.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/SettingsManager.java
@@ -38,8 +38,11 @@ public final class SettingsManager {
         // Mirror the destination onto the sidebar scoreboard whenever it changes.
         // setValue() fires listeners BEFORE storing the new value, so use newValue here, not getDestination().
         scoreboard = new DestinationScoreboard();
-        destSetting.registerListener((uuid, setting, oldValue, newValue) ->
-            scoreboard.update(Bukkit.getPlayer(uuid), newValue));
+        destSetting.registerListener((uuid, setting, oldValue, newValue) -> {
+            if (scoreboard != null) {
+                scoreboard.update(Bukkit.getPlayer(uuid), newValue);
+            }
+        });
     }
 
     /**

--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/SettingsManager.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/SettingsManager.java
@@ -2,6 +2,7 @@ package sh.okx.railswitch.settings;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import sh.okx.railswitch.RailSwitchPlugin;
@@ -17,6 +18,8 @@ public final class SettingsManager {
 
     private static ResetSetting resetSetting;
 
+    private static DestinationScoreboard scoreboard;
+
     /**
      * Initialise the settings manager. This should only be called within RailSwitch onEnable().
      *
@@ -31,6 +34,12 @@ public final class SettingsManager {
         menu.registerToParentMenu();
         menu.registerSetting(destSetting);
         menu.registerSetting(resetSetting);
+
+        // Mirror the destination onto the sidebar scoreboard whenever it changes.
+        // setValue() fires listeners BEFORE storing the new value, so use newValue here, not getDestination().
+        scoreboard = new DestinationScoreboard();
+        destSetting.registerListener((uuid, setting, oldValue, newValue) ->
+            scoreboard.update(Bukkit.getPlayer(uuid), newValue));
     }
 
     /**
@@ -38,6 +47,10 @@ public final class SettingsManager {
      */
     public static void reset() {
         // TODO: Deregister and unload all the menu elements once PlayerSettingAPI becomes reload safe
+        if (scoreboard != null) {
+            scoreboard.delete();
+            scoreboard = null;
+        }
         menu = null;
         destSetting = null;
         resetSetting = null;
@@ -80,6 +93,18 @@ public final class SettingsManager {
             return "";
         }
         return value;
+    }
+
+    /**
+     * Restores the player's destination line on the sidebar, e.g. when they log in.
+     * Reads the stored value directly because player settings are already loaded at join time.
+     *
+     * @param player The player whose destination line should be refreshed.
+     */
+    public static void restoreDestinationDisplay(Player player) {
+        if (scoreboard != null) {
+            scoreboard.update(player, getDestination(player));
+        }
     }
 
 }

--- a/plugins/railswitch-paper/src/test/java/sh/okx/railswitch/settings/DestinationScoreboardTest.java
+++ b/plugins/railswitch-paper/src/test/java/sh/okx/railswitch/settings/DestinationScoreboardTest.java
@@ -1,0 +1,38 @@
+package sh.okx.railswitch.settings;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.bukkit.ChatColor;
+import org.junit.jupiter.api.Test;
+
+class DestinationScoreboardTest {
+
+    @Test
+    void render_nullDestination_returnsNull() {
+        assertNull(DestinationScoreboard.render(null));
+    }
+
+    @Test
+    void render_emptyDestination_returnsNull() {
+        assertNull(DestinationScoreboard.render(""));
+    }
+
+    @Test
+    void render_blankDestination_returnsNull() {
+        assertNull(DestinationScoreboard.render("   "));
+    }
+
+    @Test
+    void render_value_returnsLabelledColouredLine() {
+        String expected = ChatColor.GOLD + "/dest: " + ChatColor.LIGHT_PURPLE + "Spawn";
+        assertEquals(expected, DestinationScoreboard.render("Spawn"));
+    }
+
+    @Test
+    void render_longValue_isNotTruncatedHere() {
+        String dest = "A".repeat(60);
+        String line = DestinationScoreboard.render(dest);
+        assertEquals(ChatColor.GOLD + "/dest: " + ChatColor.LIGHT_PURPLE + dest, line);
+    }
+}

--- a/plugins/railswitch-paper/src/test/java/sh/okx/railswitch/settings/DestinationScoreboardTest.java
+++ b/plugins/railswitch-paper/src/test/java/sh/okx/railswitch/settings/DestinationScoreboardTest.java
@@ -30,9 +30,8 @@ class DestinationScoreboardTest {
     }
 
     @Test
-    void render_longValue_isNotTruncatedHere() {
-        String dest = "A".repeat(60);
-        String line = DestinationScoreboard.render(dest);
-        assertEquals(ChatColor.GOLD + "/dest: " + ChatColor.LIGHT_PURPLE + dest, line);
+    void render_longValue_isCappedToFitScoreboardLine() {
+        String line = DestinationScoreboard.render("A".repeat(60));
+        assertEquals(ChatColor.GOLD + "/dest: " + ChatColor.LIGHT_PURPLE + "A".repeat(29), line);
     }
 }


### PR DESCRIPTION
## What

Shows a player's RailSwitch destination on the civmodcore sidebar as a
`/dest: <value>` line. It appears whenever the destination is set — via the
`/dest` command, sneak-right-clicking a destination sign, or the settings
menu — updates on change, hides when cleared, and is restored on login.

## How

- `DestinationScoreboard` wraps a `CivScoreBoard`; `render()` builds the gold
  `/dest: ` + light-purple value line, or returns null to hide it.
- A `SettingChangeListener` on the destination setting drives the line on every
  change — one chokepoint covering the command, sign, menu, and reset. It uses
  the listener's `newValue`, since `setValue` fires listeners before storing.
- A `PlayerJoinEvent` listener (priority `NORMAL`, after civmodcore's `LOWEST`
  scoreboard reset) restores a saved destination on login.
- The value is capped to 29 chars so the whole line stays within civmodcore's
  40-char limit. `CivScoreBoard` caches the full string but displays a
  truncated key, so an over-long line would otherwise leave a stale entry that
  never clears.

## Testing

- Unit tests for `render()`: null/empty/blank hide the line; a value renders the
  labelled line; a long value is capped.
- `./gradlew :plugins:railswitch-paper:build` passes.

This follows the same `set()`/`hide()` pattern as the other civmodcore sidebar
consumers, so it inherits their existing reload/quit bookkeeping limitations in
civmodcore (`openScores` is not purged on quit). Out of scope here.
