### PR TITLE
Add CivScheduler facade and migrate civmodcore sites

### DIFF
--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/dialog/Dialog.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/chat/dialog/Dialog.java
@@ -2,7 +2,6 @@ package vg.civcraft.mc.civmodcore.chat.dialog;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
-import org.bukkit.Bukkit;
 import org.bukkit.conversations.Conversation;
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.ConversationFactory;
@@ -11,6 +10,7 @@ import org.bukkit.conversations.StringPrompt;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import vg.civcraft.mc.civmodcore.CivModCorePlugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
 
 public abstract class Dialog {
 
@@ -33,7 +33,7 @@ public abstract class Dialog {
         Preconditions.checkNotNull(player, "Player cannot be null!");
         Preconditions.checkNotNull(plugin, "Plugin cannot be null!");
         this.player = player;
-        Bukkit.getScheduler().runTask(plugin, (Runnable) player::closeInventory);
+        CivScheduler.runEntity(player, player::closeInventory);
         this.conversation = new ConversationFactory(plugin)
             .withModality(false)
             .withLocalEcho(false)

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/gui/AnimatedClickable.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/gui/AnimatedClickable.java
@@ -3,9 +3,8 @@ package vg.civcraft.mc.civmodcore.inventory.gui;
 import java.util.List;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scheduler.BukkitTask;
-import vg.civcraft.mc.civmodcore.CivModCorePlugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
+import vg.civcraft.mc.civmodcore.scheduling.CivTask;
 
 public class AnimatedClickable extends IClickable {
 
@@ -41,12 +40,7 @@ public class AnimatedClickable extends IClickable {
     @Override
     public void addedToInventory(final ClickableInventory inv, final int slot) {
         // Schedule swapping out of item
-        BukkitTask task = new BukkitRunnable() {
-            @Override
-            public void run() {
-                inv.setItem(getNext(), slot);
-            }
-        }.runTaskTimer(CivModCorePlugin.getInstance(), timing, timing);
+        CivTask task = CivScheduler.runGlobalTimer(() -> inv.setItem(getNext(), slot), timing, timing);
         inv.registerTask(task);
     }
 

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/gui/ClickableInventory.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/inventory/gui/ClickableInventory.java
@@ -14,8 +14,8 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitTask;
-import vg.civcraft.mc.civmodcore.CivModCorePlugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
+import vg.civcraft.mc.civmodcore.scheduling.CivTask;
 
 /**
  * Represents an inventory filled with Clickables. Whenever one of those is
@@ -43,7 +43,7 @@ public class ClickableInventory {
 
     private IClickable[] clickables;
 
-    private List<BukkitTask> runnables;
+    private List<CivTask> runnables;
 
     private String name;
     private Runnable onClose;
@@ -193,7 +193,7 @@ public class ClickableInventory {
     public void showInventory(Player p, boolean eventSafe) {
         if (p != null) {
             if (eventSafe) {
-                Bukkit.getScheduler().runTask(CivModCorePlugin.getInstance(), () -> {
+                CivScheduler.runEntity(p, () -> {
                     p.openInventory(inventory);
                     openInventories.put(p.getUniqueId(), this);
                 });
@@ -245,7 +245,7 @@ public class ClickableInventory {
         inventory.setItem(slot, is);
     }
 
-    public void registerTask(BukkitTask runnable) {
+    public void registerTask(CivTask runnable) {
         this.runnables.add(runnable);
     }
 
@@ -310,7 +310,7 @@ public class ClickableInventory {
     private static void stopRunnables(ClickableInventory ci) {
         if (ci.inventory.getViewers().size() == 1) {
             // last one is closing
-            for (BukkitTask runnable : ci.runnables) {
+            for (CivTask runnable : ci.runnables) {
                 runnable.cancel();
             }
         }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/players/PlayerNames.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/players/PlayerNames.java
@@ -2,9 +2,9 @@ package vg.civcraft.mc.civmodcore.players;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.bukkit.Bukkit;
@@ -16,20 +16,23 @@ import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
 
 public final class PlayerNames implements Listener {
 
-    private static final Set<String> names = new HashSet<>();
+    // Concurrent: the async-seed task writes on the global region thread while the login handler and external
+    // getPlayerNames() callers touch it from connection/region threads under Folia.
+    private static final Set<String> names = ConcurrentHashMap.newKeySet();
 
     public PlayerNames(Plugin plugin) {
         names.clear();
-        Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+        CivScheduler.runAsync(plugin, () -> {
             OfflinePlayer[] players = Bukkit.getOfflinePlayers();
             List<String> namesList = Stream.of(players)
                 .map(OfflinePlayer::getName)
                 .filter(StringUtils::isNotBlank)
                 .toList();
-            Bukkit.getScheduler().runTask(plugin, () -> {
+            CivScheduler.runGlobal(plugin, () -> {
                 names.addAll(namesList);
             });
         });

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/players/scoreboard/bottom/BottomLine.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/players/scoreboard/bottom/BottomLine.java
@@ -3,25 +3,27 @@ package vg.civcraft.mc.civmodcore.players.scoreboard.bottom;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-import vg.civcraft.mc.civmodcore.CivModCorePlugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
+import vg.civcraft.mc.civmodcore.scheduling.CivTask;
 
 public class BottomLine implements Comparable<BottomLine> {
 
     private Map<UUID, String> texts;
     private String identifier;
-    private BukkitRunnable updater;
+    private CivTask updater;
     private int priority;
 
     BottomLine(String identifier, int priority) {
         this.identifier = identifier;
         this.priority = priority;
-        this.texts = new TreeMap<>();
+        // Mutated by event handlers on region/entity threads while the updatePeriodically task iterates it
+        // on the global thread under Folia; UUID keys are never sorted, so a hash map is enough.
+        this.texts = new ConcurrentHashMap<>();
     }
 
     public String getIdentifier() {
@@ -44,30 +46,25 @@ public class BottomLine implements Comparable<BottomLine> {
         if (updater != null) {
             updater.cancel();
         }
-        updater = new BukkitRunnable() {
-
-            @Override
-            public void run() {
-                Iterator<Entry<UUID, String>> iter = texts.entrySet().iterator();
-                while (iter.hasNext()) {
-                    Entry<UUID, String> entry = iter.next();
-                    Player player = Bukkit.getPlayer(entry.getKey());
-                    if (player != null) {
-                        String newText = updateFunction.apply(player, entry.getValue());
-                        if (newText == null) {
-                            iter.remove();
-                            BottomLineAPI.refreshIndividually(player.getUniqueId());
-                            continue;
-                        }
-                        if (!newText.equals(entry.getValue())) {
-                            entry.setValue(newText);
-                            BottomLineAPI.refreshIndividually(player.getUniqueId());
-                        }
+        updater = CivScheduler.runGlobalTimer(() -> {
+            Iterator<Entry<UUID, String>> iter = texts.entrySet().iterator();
+            while (iter.hasNext()) {
+                Entry<UUID, String> entry = iter.next();
+                Player player = Bukkit.getPlayer(entry.getKey());
+                if (player != null) {
+                    String newText = updateFunction.apply(player, entry.getValue());
+                    if (newText == null) {
+                        iter.remove();
+                        BottomLineAPI.refreshIndividually(player.getUniqueId());
+                        continue;
+                    }
+                    if (!newText.equals(entry.getValue())) {
+                        entry.setValue(newText);
+                        BottomLineAPI.refreshIndividually(player.getUniqueId());
                     }
                 }
             }
-        };
-        updater.runTaskTimer(CivModCorePlugin.getInstance(), delay, delay);
+        }, delay, delay);
     }
 
     public void removePlayer(Player player) {

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/players/scoreboard/bottom/BottomLineAPI.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/players/scoreboard/bottom/BottomLineAPI.java
@@ -9,8 +9,7 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-import vg.civcraft.mc.civmodcore.CivModCorePlugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
 
 public final class BottomLineAPI {
 
@@ -18,14 +17,7 @@ public final class BottomLineAPI {
     private static final String SEPARATOR = ChatColor.BOLD + "  " + ChatColor.BLACK + "||  " + ChatColor.RESET;
 
     public static void init() {
-        BukkitRunnable run = new BukkitRunnable() {
-
-            @Override
-            public void run() {
-                refreshAll();
-            }
-        };
-        run.runTaskTimer(CivModCorePlugin.getInstance(), 15, 15);
+        CivScheduler.runGlobalTimer(BottomLineAPI::refreshAll, 15, 15);
     }
 
     public static BottomLine createBottomLine(String identifier, int priority) {

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/players/scoreboard/side/CivScoreBoard.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/players/scoreboard/side/CivScoreBoard.java
@@ -3,27 +3,28 @@ package vg.civcraft.mc.civmodcore.players.scoreboard.side;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Score;
 import org.bukkit.scoreboard.Scoreboard;
-import vg.civcraft.mc.civmodcore.CivModCorePlugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
+import vg.civcraft.mc.civmodcore.scheduling.CivTask;
 
 public class CivScoreBoard {
 
     private String scoreName;
     private Map<UUID, String> currentScoreText;
-    private BukkitRunnable updater;
+    private CivTask updater;
 
     CivScoreBoard(String scoreName) {
         this.scoreName = scoreName;
-        this.currentScoreText = new TreeMap<>();
+        // Updater runs on the global region thread while set/hide/purge mutate from player region threads on Folia.
+        this.currentScoreText = new ConcurrentHashMap<>();
     }
 
     public String getName() {
@@ -34,30 +35,25 @@ public class CivScoreBoard {
         if (updater != null) {
             updater.cancel();
         }
-        updater = new BukkitRunnable() {
-
-            @Override
-            public void run() {
-                Iterator<Entry<UUID, String>> iter = currentScoreText.entrySet().iterator();
-                while (iter.hasNext()) {
-                    Entry<UUID, String> entry = iter.next();
-                    Player player = Bukkit.getPlayer(entry.getKey());
-                    if (player != null) {
-                        String newText = updateFunction.apply(player, entry.getValue());
-                        if (newText == null) {
-                            hideForPlayer(player);
-                            iter.remove();
-                            continue;
-                        }
-                        if (!newText.equals(entry.getValue())) {
-                            internalUpdate(player, entry.getValue(), newText);
-                            entry.setValue(newText);
-                        }
+        updater = CivScheduler.runGlobalTimer(() -> {
+            Iterator<Entry<UUID, String>> iter = currentScoreText.entrySet().iterator();
+            while (iter.hasNext()) {
+                Entry<UUID, String> entry = iter.next();
+                Player player = Bukkit.getPlayer(entry.getKey());
+                if (player != null) {
+                    String newText = updateFunction.apply(player, entry.getValue());
+                    if (newText == null) {
+                        hideForPlayer(player);
+                        iter.remove();
+                        continue;
+                    }
+                    if (!newText.equals(entry.getValue())) {
+                        internalUpdate(player, entry.getValue(), newText);
+                        entry.setValue(newText);
                     }
                 }
             }
-        };
-        updater.runTaskTimer(CivModCorePlugin.getInstance(), delay, delay);
+        }, delay, delay);
     }
 
     public void set(Player p, String newText) {

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/scheduling/CivScheduler.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/scheduling/CivScheduler.java
@@ -1,0 +1,153 @@
+package vg.civcraft.mc.civmodcore.scheduling;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import vg.civcraft.mc.civmodcore.CivModCorePlugin;
+
+/**
+ * Scheduling facade over Paper's region-aware schedulers.
+ * <p>
+ * Paper ships the Folia scheduler API on every build: on regular Paper these schedulers run on the main
+ * thread and never regionize, while on Folia they regionize. Delegating to them directly means one shadow
+ * jar runs on both with no reflection or runtime server-type detection.
+ */
+public final class CivScheduler {
+
+    private static final long MILLIS_PER_TICK = 50L;
+
+    private static final Runnable NO_OP = () -> {
+    };
+
+    private CivScheduler() {
+    }
+
+    private static Plugin plugin() {
+        return CivModCorePlugin.getInstance();
+    }
+
+    // The Folia schedulers hand the task its own ScheduledTask handle; our callers don't need it.
+    private static Consumer<ScheduledTask> ignoreHandle(final Runnable task) {
+        return ignored -> task.run();
+    }
+
+    // Global/region/entity scheduler delays and periods are in ticks and throw below 1.
+    private static long atLeastOneTick(final long ticks) {
+        return Math.max(1L, ticks);
+    }
+
+    // --- GLOBAL (main-thread on Paper, global region on Folia) ---
+
+    public static void runGlobal(final Runnable task) {
+        runGlobal(plugin(), task);
+    }
+
+    public static void runGlobal(final Plugin plugin, final Runnable task) {
+        Bukkit.getGlobalRegionScheduler().run(plugin, ignoreHandle(task));
+    }
+
+    public static CivTask runGlobalLater(final Runnable task, final long delayTicks) {
+        return runGlobalLater(plugin(), task, delayTicks);
+    }
+
+    public static CivTask runGlobalLater(final Plugin plugin, final Runnable task, final long delayTicks) {
+        return CivTask.wrap(Bukkit.getGlobalRegionScheduler()
+                .runDelayed(plugin, ignoreHandle(task), atLeastOneTick(delayTicks)));
+    }
+
+    public static CivTask runGlobalTimer(final Runnable task, final long delayTicks, final long periodTicks) {
+        return runGlobalTimer(plugin(), task, delayTicks, periodTicks);
+    }
+
+    public static CivTask runGlobalTimer(final Plugin plugin, final Runnable task, final long delayTicks,
+            final long periodTicks) {
+        return CivTask.wrap(Bukkit.getGlobalRegionScheduler()
+                .runAtFixedRate(plugin, ignoreHandle(task), atLeastOneTick(delayTicks), atLeastOneTick(periodTicks)));
+    }
+
+    // --- REGION (by location / block) ---
+
+    public static void runRegion(final Location loc, final Runnable task) {
+        Bukkit.getRegionScheduler().run(plugin(), loc, ignoreHandle(task));
+    }
+
+    public static void runRegion(final Block block, final Runnable task) {
+        runRegion(block.getLocation(), task);
+    }
+
+    public static CivTask runRegionLater(final Location loc, final Runnable task, final long delayTicks) {
+        return CivTask.wrap(Bukkit.getRegionScheduler()
+                .runDelayed(plugin(), loc, ignoreHandle(task), atLeastOneTick(delayTicks)));
+    }
+
+    public static CivTask runRegionLater(final Block block, final Runnable task, final long delayTicks) {
+        return runRegionLater(block.getLocation(), task, delayTicks);
+    }
+
+    public static CivTask runRegionTimer(final Location loc, final Runnable task, final long delayTicks,
+            final long periodTicks) {
+        return CivTask.wrap(Bukkit.getRegionScheduler()
+                .runAtFixedRate(plugin(), loc, ignoreHandle(task), atLeastOneTick(delayTicks),
+                        atLeastOneTick(periodTicks)));
+    }
+
+    public static CivTask runRegionTimer(final Block block, final Runnable task, final long delayTicks,
+            final long periodTicks) {
+        return runRegionTimer(block.getLocation(), task, delayTicks, periodTicks);
+    }
+
+    // --- ENTITY (retiredFallback runs if entity removed before task) ---
+
+    public static void runEntity(final Entity entity, final Runnable task) {
+        runEntity(entity, task, NO_OP);
+    }
+
+    public static void runEntity(final Entity entity, final Runnable task, final Runnable retiredFallback) {
+        entity.getScheduler().run(plugin(), ignoreHandle(task), retiredFallback);
+    }
+
+    public static CivTask runEntityLater(final Entity entity, final Runnable task, final Runnable retiredFallback,
+            final long delayTicks) {
+        return CivTask.wrap(entity.getScheduler()
+                .runDelayed(plugin(), ignoreHandle(task), retiredFallback, atLeastOneTick(delayTicks)));
+    }
+
+    public static CivTask runEntityTimer(final Entity entity, final Runnable task, final Runnable retiredFallback,
+            final long delayTicks, final long periodTicks) {
+        return CivTask.wrap(entity.getScheduler()
+                .runAtFixedRate(plugin(), ignoreHandle(task), retiredFallback, atLeastOneTick(delayTicks),
+                        atLeastOneTick(periodTicks)));
+    }
+
+    // --- ASYNC (off main thread) ---
+
+    public static CivTask runAsync(final Runnable task) {
+        return runAsync(plugin(), task);
+    }
+
+    public static CivTask runAsync(final Plugin plugin, final Runnable task) {
+        return CivTask.wrap(Bukkit.getAsyncScheduler().runNow(plugin, ignoreHandle(task)));
+    }
+
+    public static CivTask runAsyncLater(final Runnable task, final long delayTicks) {
+        return CivTask.wrap(Bukkit.getAsyncScheduler()
+                .runDelayed(plugin(), ignoreHandle(task), ticksToMillis(delayTicks), TimeUnit.MILLISECONDS));
+    }
+
+    public static CivTask runAsyncTimer(final Runnable task, final long delayTicks, final long periodTicks) {
+        return CivTask.wrap(Bukkit.getAsyncScheduler()
+                .runAtFixedRate(plugin(), ignoreHandle(task), ticksToMillis(delayTicks), ticksToMillis(periodTicks),
+                        TimeUnit.MILLISECONDS));
+    }
+
+    // The async scheduler works in real time, so its delay/period are expressed as ticks-equivalent millis.
+    private static long ticksToMillis(final long ticks) {
+        return atLeastOneTick(ticks) * MILLIS_PER_TICK;
+    }
+
+}

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/scheduling/CivTask.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/scheduling/CivTask.java
@@ -1,0 +1,49 @@
+package vg.civcraft.mc.civmodcore.scheduling;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+
+/**
+ * A cancellable handle to a scheduled task. Wraps Paper's {@link ScheduledTask} so call sites do not
+ * need to import the Folia scheduler types directly.
+ */
+public interface CivTask {
+
+    void cancel();
+
+    boolean isCancelled();
+
+    static CivTask wrap(final ScheduledTask task) {
+        // EntityScheduler.run*/ returns null when the entity was retired before the task could be scheduled.
+        return task == null ? NoOpCivTask.INSTANCE : new ScheduledCivTask(task);
+    }
+
+    record ScheduledCivTask(ScheduledTask task) implements CivTask {
+
+        @Override
+        public void cancel() {
+            this.task.cancel();
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return this.task.isCancelled();
+        }
+
+    }
+
+    record NoOpCivTask() implements CivTask {
+
+        static final NoOpCivTask INSTANCE = new NoOpCivTask();
+
+        @Override
+        public void cancel() {
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return true;
+        }
+
+    }
+
+}

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/DelayedItemDrop.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/DelayedItemDrop.java
@@ -2,12 +2,11 @@ package vg.civcraft.mc.civmodcore.utilities;
 
 import java.util.Collections;
 import java.util.List;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
-import vg.civcraft.mc.civmodcore.CivModCorePlugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
 
 public final class DelayedItemDrop {
 
@@ -39,11 +38,14 @@ public final class DelayedItemDrop {
 
     public static void dropAt(final Location l, final List<ItemStack> stacks) {
         // Schedule the item to drop 1 tick later
-        Bukkit.getScheduler().scheduleSyncDelayedTask(CivModCorePlugin.getInstance(), () -> {
+        CivScheduler.runRegionLater(l, () -> {
+            // Location.add mutates in place, so clone once to center the drop without
+            // accumulating the offset per stack or mutating the caller's Location.
+            final Location dropLoc = l.clone().add(0.5, 0.5, 0.5);
             for (ItemStack is : stacks) {
-                l.getWorld().dropItem(l.add(0.5, 0.5, 0.5), is).setVelocity(new Vector(0, 0.05, 0));
+                dropLoc.getWorld().dropItem(dropLoc, is).setVelocity(new Vector(0, 0.05, 0));
             }
-        }, 1);
+        }, 1L);
     }
 
 }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/DoubleInteractFixer.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/DoubleInteractFixer.java
@@ -3,21 +3,22 @@ package vg.civcraft.mc.civmodcore.utilities;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.UUID;
-import org.bukkit.Bukkit;
+import java.util.concurrent.ConcurrentHashMap;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
 
 public class DoubleInteractFixer {
 
     private Map<UUID, List<Location>> locations;
 
     public DoubleInteractFixer(Plugin plugin) {
-        locations = new TreeMap<>();
-        Bukkit.getScheduler().runTaskTimer(plugin, () -> locations.clear(), 1L, 1L);
+        // Folia: interact events run on per-region threads, the clear timer on the global thread.
+        locations = new ConcurrentHashMap<>();
+        CivScheduler.runGlobalTimer(plugin, () -> locations.clear(), 1L, 1L);
     }
 
     /**

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/SkinCache.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/SkinCache.java
@@ -17,7 +17,8 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitTask;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
+import vg.civcraft.mc.civmodcore.scheduling.CivTask;
 
 /**
  * @author caucow ( https://github.com/caucow )
@@ -30,7 +31,7 @@ public class SkinCache {
     // TODO: If an easier way to limit the number of threads spawned by Bukkit's scheduler exists, use it.
     // This is dirty. It feels bad.
     private final ExecutorService executor;
-    private final BukkitTask watchdog;
+    private final CivTask watchdog;
     private Thread watchdogThread;
     /**
      * Caching of PlayerProfiles, should only be accessed directly through
@@ -88,7 +89,7 @@ public class SkinCache {
         // because I don't trust plugins to clean up on disable so might as well
         // have something screeching in the logs. not that many plugins try to
         // be reloadable
-        this.watchdog = Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+        this.watchdog = CivScheduler.runAsync(plugin, () -> {
             watchdogThread = Thread.currentThread();
             do {
                 try {
@@ -145,7 +146,7 @@ public class SkinCache {
         metaFuture.thenAccept((asyncMeta) -> {
             if (plugin.isEnabled()) {
                 ItemStack headItem = createHeadItem(asyncMeta);
-                Bukkit.getScheduler().runTask(plugin, () -> notifyAvailable.accept(headItem));
+                CivScheduler.runGlobal(plugin, () -> notifyAvailable.accept(headItem));
             }
         });
         return placeholderSupplier.get();

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/cooldowns/TickCoolDownHandler.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/utilities/cooldowns/TickCoolDownHandler.java
@@ -2,8 +2,9 @@ package vg.civcraft.mc.civmodcore.utilities.cooldowns;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.bukkit.Bukkit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.bukkit.plugin.java.JavaPlugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
 
 /**
  * Cooldown implementation that keeps track of objects in ticks. The value given in the constructor is assumed to be in
@@ -19,25 +20,24 @@ public class TickCoolDownHandler<E> implements ICoolDownHandler<E> {
 
     private long cooldown;
 
-    private long tickCounter;
+    // Incremented on the global region thread but read by cooldown checks on region/entity threads
+    private final AtomicLong tickCounter = new AtomicLong();
 
     public TickCoolDownHandler(JavaPlugin executingPlugin, long cooldown) {
         this.cooldown = cooldown;
         cds = new HashMap<>();
-        Bukkit.getScheduler().scheduleSyncRepeatingTask(executingPlugin, () -> {
-            tickCounter++; // increment every tick
-        }, 1L, 1L);
+        CivScheduler.runGlobalTimer(executingPlugin, tickCounter::incrementAndGet, 1L, 1L);
     }
 
     @Override
     public void putOnCoolDown(E e) {
-        cds.put(e, tickCounter);
+        cds.put(e, tickCounter.get());
     }
 
     @Override
     public boolean onCoolDown(E e) {
         Long lastUsed = cds.get(e);
-        if (lastUsed == null || (tickCounter - lastUsed) > cooldown) {
+        if (lastUsed == null || (tickCounter.get() - lastUsed) > cooldown) {
             return false;
         }
         return true;
@@ -49,7 +49,7 @@ public class TickCoolDownHandler<E> implements ICoolDownHandler<E> {
         if (lastUsed == null) {
             return 0L;
         }
-        long leftOver = tickCounter - lastUsed;
+        long leftOver = tickCounter.get() - lastUsed;
         if (leftOver < cooldown) {
             return cooldown - leftOver;
         }

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/GlobalChunkMetaManager.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/GlobalChunkMetaManager.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.World;
 import vg.civcraft.mc.civmodcore.CivModCorePlugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
 import vg.civcraft.mc.civmodcore.world.locations.chunkmeta.api.ChunkMetaViewTracker;
 import vg.civcraft.mc.civmodcore.world.locations.global.CMCWorldDAO;
 import vg.civcraft.mc.civmodcore.world.locations.global.WorldIDManager;
@@ -35,7 +36,7 @@ public class GlobalChunkMetaManager {
             registerWorld(idManager.getInternalWorldId(world), world);
         }
         Bukkit.getPluginManager().registerEvents(new ChunkMetaListener(this, ChunkMetaViewTracker.getInstance()), CivModCorePlugin.getInstance());
-        Bukkit.getScheduler().scheduleSyncDelayedTask(CivModCorePlugin.getInstance(), () -> {
+        CivScheduler.runGlobalLater(() -> {
             for (World world : Bukkit.getWorlds()) {
                 for (Chunk chunk : world.getLoadedChunks()) {
                     loadChunkData(chunk);

--- a/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/api/SingleBlockAPIView.java
+++ b/plugins/civmodcore-paper/src/main/java/vg/civcraft/mc/civmodcore/world/locations/chunkmeta/api/SingleBlockAPIView.java
@@ -1,9 +1,9 @@
 package vg.civcraft.mc.civmodcore.world.locations.chunkmeta.api;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.plugin.java.JavaPlugin;
+import vg.civcraft.mc.civmodcore.scheduling.CivScheduler;
 import vg.civcraft.mc.civmodcore.world.locations.global.GlobalLocationTracker;
 import vg.civcraft.mc.civmodcore.world.locations.global.LocationTrackable;
 
@@ -23,7 +23,7 @@ public class SingleBlockAPIView<T extends LocationTrackable> extends APIView {
     SingleBlockAPIView(JavaPlugin plugin, short pluginID, GlobalLocationTracker<T> tracker) {
         super(plugin, pluginID);
         this.tracker = tracker;
-        Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, tracker::initFromDB);
+        CivScheduler.runGlobal(plugin, tracker::initFromDB);
         registerRegularSaveRunnable();
     }
 

--- a/plugins/civmodcore-paper/src/test/java/vg/civcraft/mc/civmodcore/scheduling/CivTaskTests.java
+++ b/plugins/civmodcore-paper/src/test/java/vg/civcraft/mc/civmodcore/scheduling/CivTaskTests.java
@@ -1,0 +1,64 @@
+package vg.civcraft.mc.civmodcore.scheduling;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CivTaskTests {
+
+    @Test
+    public void cancelForwardsToScheduledTask() {
+        FakeScheduledTask fake = new FakeScheduledTask();
+        CivTask task = CivTask.wrap(fake);
+
+        Assertions.assertFalse(task.isCancelled());
+
+        task.cancel();
+
+        Assertions.assertTrue(fake.cancelled);
+        Assertions.assertTrue(task.isCancelled());
+    }
+
+    @Test
+    public void isCancelledReflectsUnderlyingState() {
+        FakeScheduledTask fake = new FakeScheduledTask();
+        CivTask task = CivTask.wrap(fake);
+
+        Assertions.assertFalse(task.isCancelled());
+        fake.cancelled = true;
+        Assertions.assertTrue(task.isCancelled());
+    }
+
+    private static final class FakeScheduledTask implements ScheduledTask {
+
+        private boolean cancelled;
+
+        @Override
+        public Plugin getOwningPlugin() {
+            return null;
+        }
+
+        @Override
+        public boolean isRepeatingTask() {
+            return false;
+        }
+
+        @Override
+        public CancelledState cancel() {
+            this.cancelled = true;
+            return CancelledState.CANCELLED_BY_CALLER;
+        }
+
+        @Override
+        public ExecutionState getExecutionState() {
+            return this.cancelled ? ExecutionState.CANCELLED : ExecutionState.IDLE;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return this.cancelled;
+        }
+    }
+
+}


### PR DESCRIPTION
Foundation for Folia readiness — touches civmodcore, the linchpin imported by ~31 plugins. Already reviewed once on the fork (grepsedawk#3); review hardening is folded in.

## What
civmodcore had no scheduling abstraction: 13 call sites used `Bukkit.getScheduler()` / `BukkitRunnable` directly, which throw under Folia's regionized threading.

- New `vg.civcraft.mc.civmodcore.scheduling.CivScheduler` — `runGlobal` / `runRegion(Location|Block)` / `runEntity` / `runAsync`, each with `Later` and `Timer` variants returning a cancellable `CivTask`.
- Delegates directly to the region-aware schedulers Paper exposes on **every** build (`getGlobalRegionScheduler` / `getRegionScheduler` / `getAsyncScheduler` / `Entity#getScheduler`). On regular Paper these run on the main thread; on Folia they regionize. **No reflection, no runtime server-type detection — one shadow jar runs on both.** (API presence verified against paper-api 1.21.8 via `javap`.)
- Migrated all 13 civmodcore call sites. Block/entity work routes to the region/entity schedulers so it stays correct when regionized.

## Thread-safety hardening
Moving these sites onto region schedulers means a global-thread timer now touches state that region/entity-thread event handlers also write. Made those structures concurrent:
- `DoubleInteractFixer`, `BottomLine`, `CivScoreBoard`: `TreeMap` → `ConcurrentHashMap` (UUID keys, no ordering relied upon).
- `PlayerNames`: `HashSet` → `ConcurrentHashMap.newKeySet()`.
- `TickCoolDownHandler`: `tickCounter` → `AtomicLong`.

Plus two latent bugs the migration exposed: `DelayedItemDrop` mutated the caller's `Location` cumulatively in its drop loop (clone once); `CivTask.wrap` wrapped a null handle when the entity scheduler declined a retired entity (return a no-op task).

## Tests
`CivTaskTests` (wrap/cancel/no-op). `./gradlew :plugins:civmodcore-paper:test` BUILD SUCCESSFUL; existing suites pass. No `Bukkit.getScheduler()` / `BukkitRunnable` remain in main source outside the facade.

## Notes for reviewers
- Adds a small public API on a heavily-imported module; the facade overload set is deliberately complete to serve the upcoming downstream migrations.
- aikar `taskchain` (used only by jukealert) is **out of scope** — not Folia-safe, but the facade only replaces direct Bukkit-scheduler sites.
- Two **pre-existing** Folia concerns preserved as faithful mappings, flagged for follow-up: `GlobalChunkMetaManager` iterates all worlds/loaded chunks from the global region (cross-region iteration isn't thread-safe on Folia); and the same race class extends to a few collections adjacent to the migrated ones (`BottomLineAPI.lines`, `ScoreBoardAPI` registries, `TickCoolDownHandler.cds`, the inner list in `DoubleInteractFixer`) — worth a dedicated pass.

This is the gate for migrating the ~300 scheduler sites across dependent plugins.
