### PR TITLE
Retype bastions to match their world block

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "temurin-21.0.11"

--- a/plugins/bastion-paper/src/main/java/isaac/bastion/Bastion.java
+++ b/plugins/bastion-paper/src/main/java/isaac/bastion/Bastion.java
@@ -6,6 +6,7 @@ import isaac.bastion.commands.PlayersStates.Mode;
 import isaac.bastion.listeners.BastionBreakListener;
 import isaac.bastion.listeners.BastionDamageListener;
 import isaac.bastion.listeners.BastionInteractListener;
+import isaac.bastion.listeners.ChunkReconcileListener;
 import isaac.bastion.listeners.CitadelListener;
 import isaac.bastion.listeners.ElytraListener;
 import isaac.bastion.listeners.ModeListener;
@@ -73,6 +74,7 @@ public final class Bastion extends ACivMod {
         getServer().getPluginManager().registerEvents(new NameLayerListener(blockStorage), this);
         getServer().getPluginManager().registerEvents(new CitadelListener(), this);
         getServer().getPluginManager().registerEvents(new ModeListener(), this);
+        getServer().getPluginManager().registerEvents(new ChunkReconcileListener(blockStorage), this);
     }
 
     private void setupDatabase() {

--- a/plugins/bastion-paper/src/main/java/isaac/bastion/BastionBlock.java
+++ b/plugins/bastion-paper/src/main/java/isaac/bastion/BastionBlock.java
@@ -27,7 +27,8 @@ public class BastionBlock implements QTBox, Comparable<BastionBlock> {
     private Location location;
     private int id = -1;
     private long placed; //time when the bastion block was created
-    private BastionType type;
+    // volatile: the reconciler retypes in place on the main thread while async erosion/regen read it.
+    private volatile BastionType type;
     private volatile Integer listGroupId;
 
     /**
@@ -280,6 +281,16 @@ public class BastionBlock implements QTBox, Comparable<BastionBlock> {
      */
     public BastionType getType() {
         return type;
+    }
+
+    /**
+     * Replaces the bastion's type in place. Only the reconciler calls this, to correct a row whose
+     * stored type drifted from its world block. Safe to mutate live because the TreeSet ordering
+     * ({@link #compareTo}) is location-only, so the object keeps its slot; callers must still update
+     * the spatial index, whose rectangle depends on the type's radius.
+     */
+    public void setType(BastionType type) {
+        this.type = type;
     }
 
     /**

--- a/plugins/bastion-paper/src/main/java/isaac/bastion/BastionType.java
+++ b/plugins/bastion-paper/src/main/java/isaac/bastion/BastionType.java
@@ -461,6 +461,24 @@ public class BastionType {
         return types.get(name);
     }
 
+    /**
+     * Finds the configured type whose block material is {@code material}, ignoring item name and
+     * lore. A placed world block carries neither, so the reconciler uses this to recover the type a
+     * block was meant to be. Returns the first match; a config with two types sharing a material is
+     * ambiguous and resolves to load order.
+     */
+    public static BastionType getByMaterial(Material material) {
+        if (material == null) {
+            return null;
+        }
+        for (BastionType type : types.values()) {
+            if (material.equals(type.getMaterial())) {
+                return type;
+            }
+        }
+        return null;
+    }
+
     public static BastionType getBastionType(Material mat, String itemName, List<String> lore) {
         if (lore != null && lore.size() == 0) lore = null;
         for (BastionType type : types.values()) {

--- a/plugins/bastion-paper/src/main/java/isaac/bastion/listeners/ChunkReconcileListener.java
+++ b/plugins/bastion-paper/src/main/java/isaac/bastion/listeners/ChunkReconcileListener.java
@@ -1,0 +1,54 @@
+package isaac.bastion.listeners;
+
+import isaac.bastion.Bastion;
+import isaac.bastion.BastionBlock;
+import isaac.bastion.BastionType;
+import isaac.bastion.storage.BastionBlockStorage;
+import java.util.logging.Level;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.ChunkLoadEvent;
+
+/**
+ * Heals bastions whose stored type drifted from their world block, as their chunks load. The legacy
+ * "old bastion" migration defaulted every pre-existing row to the first configured type
+ * (citybastion) without converting the physical blocks, so old sponge bastions are recorded as
+ * 50-radius city bastions. The block wins: such a row is retyped to the type whose material matches.
+ *
+ * <p>Cheap by construction -- it only inspects the bastions the index already knows are in the chunk
+ * (one block each), never scanning for blocks. The retype is in place with an async-persisted DB
+ * write (see {@link BastionBlockStorage#retypeBastion}).
+ */
+public class ChunkReconcileListener implements Listener {
+
+    private final BastionBlockStorage storage;
+
+    public ChunkReconcileListener(BastionBlockStorage storage) {
+        this.storage = storage;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onChunkLoad(ChunkLoadEvent event) {
+        Chunk chunk = event.getChunk();
+        int retyped = 0;
+        for (BastionBlock bastion : storage.getBastionsInChunk(chunk.getWorld(), chunk.getX(), chunk.getZ())) {
+            Location loc = bastion.getLocation();
+            Material raw = chunk.getBlock(loc.getBlockX() & 15, loc.getBlockY(), loc.getBlockZ() & 15).getType();
+            // A sponge bastion next to water reads back as WET_SPONGE; treat it as its dry type.
+            BastionType want = BastionType.getByMaterial(raw == Material.WET_SPONGE ? Material.SPONGE : raw);
+            if (want != null && !want.equals(bastion.getType())) {
+                storage.retypeBastion(bastion, want);
+                retyped++;
+            }
+        }
+        if (retyped > 0) {
+            Bastion.getPlugin().getLogger().log(Level.INFO,
+                "Reconciled {0} bastion(s) to match their block in chunk {1},{2}",
+                new Object[] {retyped, chunk.getX(), chunk.getZ()});
+        }
+    }
+}

--- a/plugins/bastion-paper/src/main/java/isaac/bastion/storage/BastionBlockStorage.java
+++ b/plugins/bastion-paper/src/main/java/isaac/bastion/storage/BastionBlockStorage.java
@@ -2,6 +2,7 @@ package isaac.bastion.storage;
 
 import com.github.davidmoten.rtree2.Entry;
 import com.github.davidmoten.rtree2.RTree;
+import com.github.davidmoten.rtree2.geometry.Geometries;
 import com.github.davidmoten.rtree2.geometry.Rectangle;
 import com.github.davidmoten.rtree2.geometry.internal.PointDouble;
 import isaac.bastion.Bastion;
@@ -18,8 +19,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.bukkit.Bukkit;
@@ -46,8 +49,14 @@ public class BastionBlockStorage {
 
     private HashMap<Location, BastionType> pendingBastions;
 
+    // Bastions the reconciler retyped, queued on the main thread and drained off-thread by the
+    // flush task, so the lazy chunk-load heal never blocks a tick on JDBC.
+    private final Queue<BastionBlock> pendingTypeChanges = new ConcurrentLinkedQueue<>();
+    private int typeFlushTaskId;
+
     private static final String addBastion = "insert into bastion_blocks (bastion_type, loc_x, loc_y, loc_z, loc_world, placed) values (?,?,?,?,?,?);";
     private static final String updateBastion = "update bastion_blocks set placed=? where bastion_id=?;";
+    private static final String updateBastionType = "update bastion_blocks set bastion_type=? where bastion_id=?;";
     private static final String deleteBastion = "delete from bastion_blocks where bastion_id=?;";
     private static final String setDead = "update bastion_blocks set dead=1 where bastion_id=?;";
     private static final String deleteDead = "delete from bastion_blocks where loc_world=? and loc_x=? and loc_y=? and loc_z=?;";
@@ -69,6 +78,13 @@ public class BastionBlockStorage {
                 update();
             }
         }.runTaskTimer(Bastion.getPlugin(), saveDelay, saveDelay).getTaskId();
+        // Persist queued reconciler retypes off the main thread, batched, a few times a minute.
+        typeFlushTaskId = new BukkitRunnable() {
+            @Override
+            public void run() {
+                flushTypeChanges();
+            }
+        }.runTaskTimerAsynchronously(Bastion.getPlugin(), 200L, 200L).getTaskId();
     }
 
     /**
@@ -76,7 +92,32 @@ public class BastionBlockStorage {
      */
     public void close() {
         Bukkit.getScheduler().cancelTask(taskId);
+        Bukkit.getScheduler().cancelTask(typeFlushTaskId);
         update();
+        flushTypeChanges();
+    }
+
+    /**
+     * Drains queued reconciler retypes into one batched UPDATE. Runs off the main thread. A failed
+     * flush just drops the batch: the in-memory type is already correct, and the next time the
+     * bastion's chunk loads the reconciler re-detects the drift and re-queues the write.
+     */
+    private void flushTypeChanges() {
+        if (pendingTypeChanges.isEmpty()) {
+            return;
+        }
+        try (Connection conn = db.getConnection();
+             PreparedStatement ps = conn.prepareStatement(updateBastionType)) {
+            BastionBlock bastion;
+            while ((bastion = pendingTypeChanges.poll()) != null) {
+                ps.setString(1, bastion.getType().getName());
+                ps.setInt(2, bastion.getId());
+                ps.addBatch();
+            }
+            ps.executeBatch();
+        } catch (SQLException e) {
+            log.log(Level.WARNING, "Failed to flush bastion type corrections", e);
+        }
     }
 
     /**
@@ -120,6 +161,28 @@ public class BastionBlockStorage {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Retypes a bastion in place to match its world block, queuing the DB write for the async
+     * flusher. The object keeps its slot in the {@code bastions} TreeSet (ordering is location-only),
+     * so this never structurally mutates that set -- which matters because the erosion/regen tasks
+     * iterate it on async threads without locking. Only the per-world R-tree is updated (its
+     * rectangle depends on the type's radius); {@code blocks} is touched solely on the main thread.
+     * Must be called on the main thread.
+     */
+    public void retypeBastion(BastionBlock bastion, BastionType newType) {
+        World world = bastion.getLocation().getWorld();
+        RTree<BastionBlock, Rectangle> tree = blocks.get(world);
+        if (tree != null) {
+            // Delete keyed by the OLD rectangle (old radius) before the type changes under it.
+            tree = tree.delete(bastion, bastion.asRectangle());
+            bastion.setType(newType);
+            blocks.put(world, tree.add(bastion, bastion.asRectangle()));
+        } else {
+            bastion.setType(newType);
+        }
+        pendingTypeChanges.add(bastion);
     }
 
     /**
@@ -232,6 +295,35 @@ public class BastionBlockStorage {
             }
         }
         return result;
+    }
+
+    /**
+     * All bastions whose block sits in the given chunk. The R-tree is keyed by each bastion's field
+     * extent, so a chunk-rectangle search returns every bastion whose field overlaps the chunk; the
+     * result is filtered down to those whose block actually lands in it.
+     */
+    public List<BastionBlock> getBastionsInChunk(World world, int chunkX, int chunkZ) {
+        RTree<BastionBlock, Rectangle> tree = blocks.get(world);
+        if (tree == null) {
+            return List.of();
+        }
+        int minX = chunkX << 4;
+        int minZ = chunkZ << 4;
+        Iterable<Entry<BastionBlock, Rectangle>> search =
+            tree.search(Geometries.rectangle(minX, minZ, minX + 15, minZ + 15));
+        // Lazily allocated: the overwhelmingly common chunk has no bastion and allocates nothing.
+        List<BastionBlock> result = null;
+        for (Entry<BastionBlock, Rectangle> entry : search) {
+            BastionBlock bastion = entry.value();
+            if ((bastion.getLocation().getBlockX() >> 4) == chunkX
+                && (bastion.getLocation().getBlockZ() >> 4) == chunkZ) {
+                if (result == null) {
+                    result = new ArrayList<>();
+                }
+                result.add(bastion);
+            }
+        }
+        return result == null ? List.of() : result;
     }
 
     /**

--- a/plugins/bastion-paper/src/test/java/isaac/bastion/BastionTypeTest.java
+++ b/plugins/bastion-paper/src/test/java/isaac/bastion/BastionTypeTest.java
@@ -1,0 +1,69 @@
+package isaac.bastion;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.bukkit.Material;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers {@link BastionType#getByMaterial}, the material-only lookup the chunk reconciler relies on
+ * to recover a placed block's intended type. Types are injected into the static registry by
+ * reflection, since loading them from config needs a running server.
+ */
+class BastionTypeTest {
+
+    private BastionType spongeType;
+    private BastionType cityType;
+    private BastionType claimType;
+
+    @BeforeEach
+    void seedTypes() throws Exception {
+        spongeType = typeMock(Material.SPONGE);
+        cityType = typeMock(Material.NETHER_WART_BLOCK);
+        claimType = typeMock(Material.BONE_BLOCK);
+
+        Map<String, BastionType> types = typesMap();
+        types.clear();
+        types.put("citybastion", cityType);
+        types.put("claimbastion", claimType);
+        types.put("bastion", spongeType);
+    }
+
+    @AfterEach
+    void clearTypes() throws Exception {
+        typesMap().clear();
+    }
+
+    private static BastionType typeMock(Material material) {
+        BastionType type = mock(BastionType.class);
+        lenient().when(type.getMaterial()).thenReturn(material);
+        return type;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, BastionType> typesMap() throws Exception {
+        Field field = BastionType.class.getDeclaredField("types");
+        field.setAccessible(true);
+        return (Map<String, BastionType>) field.get(null);
+    }
+
+    @Test
+    void getByMaterial_resolvesEachConfiguredMaterial() {
+        assertSame(spongeType, BastionType.getByMaterial(Material.SPONGE));
+        assertSame(cityType, BastionType.getByMaterial(Material.NETHER_WART_BLOCK));
+        assertSame(claimType, BastionType.getByMaterial(Material.BONE_BLOCK));
+    }
+
+    @Test
+    void getByMaterial_returnsNullForNonBastionMaterialOrNull() {
+        assertNull(BastionType.getByMaterial(Material.STONE), "non-bastion material has no type");
+        assertNull(BastionType.getByMaterial(null));
+    }
+}


### PR DESCRIPTION
## What

Heal bastions whose stored type no longer matches their world block.

## Why

The legacy "old bastion" migration added the `bastion_type` column with
`DEFAULT 'citybastion'`, so every pre-existing bastion was recorded as a
50-radius city bastion while its world block stayed `SPONGE`. Those bastions
enforce the wrong field and drop the wrong item when broken.

The correct type can only be recovered from the block itself — the lone type
column in the table is the corrupted one — and a block can only be read once
its chunk is loaded. So a SQL migration can't fix this, and a proactive
startup sweep would have to force-load the whole world and freeze the server.

## How

A `ChunkLoadEvent` listener retypes any bastion whose stored type no longer
matches its block, treating the block as the source of truth. The world heals
gradually as chunks load during normal play, and the correction persists
across restarts.

It stays cheap on the hot path:

- only inspects bastions the index already knows are in the chunk (one block
  read each — no block scanning);
- retypes **in place**, so it never structurally mutates the bastion set that
  the async erosion/regen tasks iterate (avoids `ConcurrentModificationException`);
- batches the DB writes **off the main thread**.

## Notes

- Pins JDK 21 via `mise.toml` so the build runs on the required toolchain.
- Sponge-orphan recovery (a reinforced sponge with no row, left behind by the
  destroy-on-cache-miss bug) is intentionally out of scope here — it needs a
  block sweep or a Citadel per-chunk reinforcement enumeration, which is a
  cleaner follow-up.

## Testing

`./gradlew :plugins:bastion-paper:test` — green (11 tests).
