### PR TITLE
Guard null bastion group in the BSI overlay

### DIFF
--- a/plugins/bastion-paper/src/main/java/isaac/bastion/listeners/ModeListener.java
+++ b/plugins/bastion-paper/src/main/java/isaac/bastion/listeners/ModeListener.java
@@ -28,6 +28,7 @@ import vg.civcraft.mc.civmodcore.players.settings.PlayerSetting;
 import vg.civcraft.mc.civmodcore.players.settings.SettingChangeListener;
 import vg.civcraft.mc.civmodcore.players.settings.impl.DisplayLocationSetting;
 import vg.civcraft.mc.namelayer.NameLayerAPI;
+import vg.civcraft.mc.namelayer.group.Group;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
 public class ModeListener implements Listener {
@@ -110,7 +111,11 @@ public class ModeListener implements Listener {
         Set<BastionType> alliedBastions = new HashSet<>();
         Set<BastionType> enemyBastions = new HashSet<>();
         for (BastionBlock bastion : bastionBlocks) {
-            if (NameLayerAPI.getGroupManager().hasAccess(bastion.getGroup(), player.getUniqueId(), placePerm)) {
+            // getGroup() is null when the bastion's reinforcement isn't loaded (its block sits on an
+            // unloaded chunk at the field edge). Treat that as not-allied without asking hasAccess,
+            // which otherwise logs a stack trace for the null group on every move event.
+            Group group = bastion.getGroup();
+            if (group != null && NameLayerAPI.getGroupManager().hasAccess(group, player.getUniqueId(), placePerm)) {
                 alliedBastions.add(bastion.getType());
             } else {
                 enemyBastions.add(bastion.getType());


### PR DESCRIPTION
## Problem

NameLayer spams the console with a full stack trace on every player move:

```
[NameLayer] hasAccess failed, caller passed in null
java.lang.Exception: null
    at GroupManager.hasAccess(GroupManager.java:438)
    at ModeListener.updateDisplayedInformation(ModeListener.java:113)
    at ModeListener.onPlayerMove(ModeListener.java:83)
```

## Root cause

The BSI overlay calls `hasAccess(bastion.getGroup(), ...)` for each blocking bastion. `getGroup()` returns null when the bastion's reinforcement isn't loaded — its block sits on an unloaded chunk at the field edge while the field still covers the moving player. NameLayer's `hasAccess` treats a null group as a caller bug and logs `new Exception()` at INFO, so every qualifying move event prints a stack trace.

## Fix

Resolve the group once and skip the `hasAccess` call when it's null, classifying the bastion as not-allied directly. Display behaviour is unchanged — an unresolved group already fell into the enemy bucket — it just no longer routes a null through `hasAccess`.

## Notes

- A companion change in NameLayer's `hasAccess` makes a null group a quiet deny (a null *perm* is still logged as a real caller bug); this Bastion guard is defense-in-depth on the caller side and also avoids the redundant lookup.
- Out of scope: `GroupManager.getGroup(int)` still does a synchronous DB query on the main thread on cache miss.