### PR TITLE
Stop auto mode repairing healthy factories

### DIFF
--- a/plugins/factorymod-paper/build.gradle.kts
+++ b/plugins/factorymod-paper/build.gradle.kts
@@ -13,4 +13,7 @@ dependencies {
     compileOnly(project(":plugins:namelayer-paper"))
     compileOnly(project(":plugins:citadel-paper"))
     compileOnly(project(":plugins:heliodor-paper"))
+
+    testImplementation(libs.bundles.junit)
+    testImplementation("org.mockito:mockito-core:5.11.0")
 }

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import com.github.igotyou.FactoryMod.utility.MultiInventoryWrapper;
 import org.bukkit.Bukkit;
@@ -57,6 +58,7 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
     protected int currentProductionTimer = 0;
     protected List<IRecipe> recipes;
     protected IRecipe currentRecipe;
+    private IRecipe preferredRecipe;
     protected Map<IRecipe, Integer> runCount;
     protected Map<IRecipe, Integer> recipeLevel;
     private UUID activator;
@@ -295,8 +297,10 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
                 }
             }
 
-            // If we run out of input materials, try to auto-select a new recipe
-            if (!hasInputMaterials()) {
+            // Re-select when out of materials, or when holding a repair recipe on a
+            // factory that isn't broken (auto mode must never repair a healthy factory)
+            boolean healthyButRepairing = currentRecipe instanceof RepairRecipe && !rm.inDisrepair();
+            if (!hasInputMaterials() || healthyButRepairing) {
                 IRecipe autoSelected = getAutoSelectRecipe();
                 if (autoSelected == null) {
                     if (p != null) {
@@ -669,6 +673,26 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
         }
     }
 
+    /**
+     * Sets the recipe in response to an explicit player selection, recording it as
+     * the preferred recipe so auto mode returns to it after any automatic detour
+     * (e.g. a repair). One-off manual repairs don't become the preference.
+     */
+    public void setRecipeManually(IRecipe pr) {
+        setRecipe(pr);
+        if (currentRecipe == pr && !(pr instanceof RepairRecipe)) {
+            preferredRecipe = pr;
+        }
+    }
+
+    public IRecipe getPreferredRecipe() {
+        return preferredRecipe;
+    }
+
+    public void setPreferredRecipe(IRecipe pr) {
+        preferredRecipe = pr;
+    }
+
     public void setRecipeForce(IRecipe pr) {
         currentRecipe = pr;
     }
@@ -736,24 +760,36 @@ public class FurnCraftChestFactory extends Factory implements IIOFInventoryProvi
      * @return null if no suitable recipe was found
      */
     public IRecipe getAutoSelectRecipe() {
-        var selectedRecipe = recipes.stream()
-            .filter(it -> {
-                // We want to select a repair recipe if and only if the factory is in disrepair
-                if (rm.inDisrepair()) {
-                    return it instanceof RepairRecipe;
-                } else {
-                    return !(it instanceof RepairRecipe);
-                }
-            })
-            .filter(it -> it.enoughMaterialAvailable(getInputInventory()))
-            .findFirst()
-            .orElse(null);
+        IRecipe selectedRecipe = chooseAutoRecipe(recipes, rm.inDisrepair(), preferredRecipe,
+            it -> it instanceof RepairRecipe,
+            it -> it.enoughMaterialAvailable(getInputInventory()));
 
         if (selectedRecipe != null) {
             LoggingUtils.log("Auto-selected recipe " + selectedRecipe.getName());
         }
 
         return selectedRecipe;
+    }
+
+    /**
+     * Picks the recipe auto mode should run. A recipe is eligible only when its
+     * repair-ness matches the factory state: repair recipes when in disrepair,
+     * production recipes otherwise. Among eligible recipes the player's preferred
+     * one wins when it's still runnable, otherwise the first eligible recipe with
+     * enough materials is used. Pure so it can be unit tested without a live factory.
+     */
+    static IRecipe chooseAutoRecipe(List<IRecipe> recipes, boolean inDisrepair, IRecipe preferred,
+                                    Predicate<IRecipe> isRepair, Predicate<IRecipe> hasMaterials) {
+        Predicate<IRecipe> eligible = it -> inDisrepair == isRepair.test(it);
+        if (!inDisrepair && preferred != null && eligible.test(preferred)
+            && recipes.contains(preferred) && hasMaterials.test(preferred)) {
+            return preferred;
+        }
+        return recipes.stream()
+            .filter(eligible)
+            .filter(hasMaterials)
+            .findFirst()
+            .orElse(null);
     }
 
     /**

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/interactionManager/FurnCraftChestInteractionManager.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/interactionManager/FurnCraftChestInteractionManager.java
@@ -296,7 +296,7 @@ public class FurnCraftChestInteractionManager implements IInteractionManager {
                     if (fccf.isActive()) {
                         p.sendMessage(ChatColor.RED + "You can't switch recipes while the factory is running");
                     } else {
-                        fccf.setRecipe(recipe);
+                        fccf.setRecipeManually(recipe);
                         p.sendMessage(ChatColor.GREEN + "Switched recipe to " + recipe.getName());
                         ComponableInventory compInv = buildRecipeInventory(p);
                         compInv.update();

--- a/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/FileHandler.java
+++ b/plugins/factorymod-paper/src/main/java/com/github/igotyou/FactoryMod/utility/FileHandler.java
@@ -84,6 +84,8 @@ public class FileHandler {
                     config.set(current + ".runtime", fccf.getRunningTime());
                     config.set(current + ".selectedRecipe", fccf
                         .getCurrentRecipe().getName());
+                    config.set(current + ".preferredRecipe", fccf.getPreferredRecipe() == null
+                        ? null : fccf.getPreferredRecipe().getName());
                     config.set(current + ".autoSelect", fccf.isAutoSelect());
                     List<String> recipeList = new LinkedList<String>();
                     for (IRecipe rec : fccf.getRecipes()) {
@@ -299,6 +301,15 @@ public class FileHandler {
                         }
                     }
                     fac.setAutoSelect(autoSelect);
+                    String preferredRecipe = current.getString("preferredRecipe");
+                    if (preferredRecipe != null) {
+                        for (IRecipe r : fac.getRecipes()) {
+                            if (r.getName().equals(preferredRecipe)) {
+                                fac.setPreferredRecipe(r);
+                                break;
+                            }
+                        }
+                    }
                 {
                     ConfigurationSection iosec = current.getConfigurationSection("furnace-io");
                     if (iosec != null) {

--- a/plugins/factorymod-paper/src/test/java/com/github/igotyou/FactoryMod/factories/ChooseAutoRecipeTest.java
+++ b/plugins/factorymod-paper/src/test/java/com/github/igotyou/FactoryMod/factories/ChooseAutoRecipeTest.java
@@ -1,0 +1,73 @@
+package com.github.igotyou.FactoryMod.factories;
+
+import com.github.igotyou.FactoryMod.recipes.IRecipe;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+class ChooseAutoRecipeTest {
+
+    private final IRecipe production1 = mock(IRecipe.class);
+    private final IRecipe production2 = mock(IRecipe.class);
+    private final IRecipe repair = mock(IRecipe.class);
+
+    private final Predicate<IRecipe> isRepair = r -> r == repair;
+
+    private static Predicate<IRecipe> hasMaterials(IRecipe... withMaterials) {
+        Set<IRecipe> set = Set.of(withMaterials);
+        return set::contains;
+    }
+
+    @Test
+    void healthyPrefersPlayerChoiceOverFirstInList() {
+        IRecipe chosen = FurnCraftChestFactory.chooseAutoRecipe(
+            List.of(production1, production2, repair), false, production2,
+            isRepair, hasMaterials(production1, production2));
+        assertSame(production2, chosen);
+    }
+
+    @Test
+    void healthyFallsBackToFirstAvailableWhenPreferredLacksMaterials() {
+        IRecipe chosen = FurnCraftChestFactory.chooseAutoRecipe(
+            List.of(production1, production2, repair), false, production2,
+            isRepair, hasMaterials(production1));
+        assertSame(production1, chosen);
+    }
+
+    @Test
+    void healthyNeverRunsRepairEvenWhenCurrentlySelected() {
+        IRecipe chosen = FurnCraftChestFactory.chooseAutoRecipe(
+            List.of(production1, repair), false, production1,
+            isRepair, hasMaterials(production1, repair));
+        assertSame(production1, chosen);
+    }
+
+    @Test
+    void healthyStaysIdleWhenNoProductionHasMaterials() {
+        IRecipe chosen = FurnCraftChestFactory.chooseAutoRecipe(
+            List.of(production1, repair), false, production1,
+            isRepair, hasMaterials(repair));
+        assertNull(chosen);
+    }
+
+    @Test
+    void brokenRunsRepairRegardlessOfPreferred() {
+        IRecipe chosen = FurnCraftChestFactory.chooseAutoRecipe(
+            List.of(production1, repair), true, production1,
+            isRepair, hasMaterials(production1, repair));
+        assertSame(repair, chosen);
+    }
+
+    @Test
+    void brokenWithNoRepairRecipeReturnsNull() {
+        IRecipe chosen = FurnCraftChestFactory.chooseAutoRecipe(
+            List.of(production1, production2), true, null,
+            isRepair, hasMaterials(production1, production2));
+        assertNull(chosen);
+    }
+}


### PR DESCRIPTION
A factory in auto mode kept running its repair recipe on every redstone pulse, even at full health. With a repair kit in the chest, it burned through kits to fix nothing. This came up in-game on a compactor running on a monthly clock.

Auto mode now only repairs when the factory is fully broken. The rest of the time it runs production, and after a repair it returns to the recipe the player selected rather than the first one in the recipe list. That preference is persisted, so it survives a restart.

The recipe-selection decision moved into a pure method, `chooseAutoRecipe`, with unit tests covering the broken, healthy, and out-of-materials cases.

Manual repair behaves as before, and a fully broken factory still auto-repairs back to full.
