### PR TITLE
Guard /nl GUI against null member names

### DIFF
--- a/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
+++ b/plugins/namelayer-paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
@@ -337,7 +337,7 @@ public class MainGroupGUI extends AbstractGroupGUI {
         }
         List<UUID> allMembers = g.getAllMembers();
         allMembers.sort(Comparator.comparing(g::isOwner).thenComparing(g::getPlayerType).reversed()
-            .thenComparing(NameLayerAPI::getCurrentName, String.CASE_INSENSITIVE_ORDER));
+            .thenComparing(NameLayerAPI::getCurrentName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
         for (UUID uuid : allMembers) {
             Clickable c = null;
             switch (g.getPlayerType(uuid)) {


### PR DESCRIPTION
Opening `/nl <group>` throws a NullPointerException when name-api returns null for any member. The member list sorts by current name with `String.CASE_INSENSITIVE_ORDER`, which dereferences the name to compare characters, so one null member crashes the whole GUI before it opens.

`Comparator.nullsLast` sorts null-named members to the end instead of crashing.

This does not fix the underlying name-api error. name-api is populated separately and can be stale or unreachable; until that connection is healthy, those members still resolve to null and render as "null" in the GUI. This change only ensures `/nl` stays usable under those same conditions instead of failing to open.