### PR TITLE
Show real decay rate in pearl time remaining

### DIFF
--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/ExilePearlApi.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/ExilePearlApi.java
@@ -26,6 +26,18 @@ public interface ExilePearlApi extends Plugin, PearlAccess, PearlLogger, PlayerP
     PearlConfig getPearlConfig();
 
     /**
+     * Gets the effective per-tick decay amount for a pearl, accounting for external modifiers
+     * (e.g. vote-streak multipliers from other plugins) applied via {@link com.devotedmc.ExilePearl.event.PearlDecayEvent}.
+     * <p>
+     * This fires a preview decay event and reads back the resulting amount, so lore and the real
+     * decay loop agree on how fast a pearl actually decays.
+     *
+     * @param pearl The pearl to evaluate
+     * @return The decay amount that would be applied per decay tick, or 0 if decay is cancelled
+     */
+    int getEffectivePearlDecayAmount(ExilePearl pearl);
+
+    /**
      * Gets the pearl lore provider
      *
      * @return The lore provider

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/CoreLoreGenerator.java
@@ -85,10 +85,11 @@ final class CoreLoreGenerator implements LoreProvider {
 
         lore.add(parse("<a>Health: <n>%s/%s", health, config.getPearlHealthMaxValue()));
         String unit = config.getPearlHealthDecayHumanInterval();
+        int effectiveDecayAmount = ExilePearlPlugin.getApi().getEffectivePearlDecayAmount(pearl);
         int decayPerHumanInterval = PearlDecayMath.decayPerHumanInterval(
             config.getPearlHealthDecayHumanIntervalMin(),
             config.getPearlHealthDecayIntervalMin(),
-            config.getPearlHealthDecayAmount());
+            effectiveDecayAmount);
         int intervalsRemaining = PearlDecayMath.intervalsRemaining(health, decayPerHumanInterval);
         if (intervalsRemaining > 0 && pearl.isActive()) {
             lore.add(parse("<a>Time remaining: <n>%d %s", intervalsRemaining, unit));

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/ExilePearlCore.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/core/ExilePearlCore.java
@@ -3,6 +3,7 @@ package com.devotedmc.ExilePearl.core;
 import com.devotedmc.ExilePearl.*;
 import com.devotedmc.ExilePearl.command.*;
 import com.devotedmc.ExilePearl.config.PearlConfig;
+import com.devotedmc.ExilePearl.event.PearlDecayEvent;
 import com.devotedmc.ExilePearl.holder.PearlHolder;
 import com.devotedmc.ExilePearl.listener.BanStickListener;
 import com.devotedmc.ExilePearl.listener.BastionListener;
@@ -257,6 +258,13 @@ final class ExilePearlCore implements ExilePearlApi {
     @Override
     public PearlConfig getPearlConfig() {
         return pearlConfig;
+    }
+
+    @Override
+    public int getEffectivePearlDecayAmount(ExilePearl pearl) {
+        PearlDecayEvent preview = new PearlDecayEvent(pearl, pearlConfig.getPearlHealthDecayAmount(), true);
+        getServer().getPluginManager().callEvent(preview);
+        return preview.isCancelled() ? 0 : preview.getDamageAmount();
     }
 
     /**

--- a/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/event/PearlDecayEvent.java
+++ b/plugins/exilepearl-paper/src/main/java/com/devotedmc/ExilePearl/event/PearlDecayEvent.java
@@ -22,6 +22,7 @@ public class PearlDecayEvent extends Event implements Cancellable {
     private boolean cancelled;
     private ExilePearl pearl;
     private int amount;
+    private final boolean preview;
 
     /**
      * Creates a new PearlDecayEvent instance.
@@ -30,9 +31,30 @@ public class PearlDecayEvent extends Event implements Cancellable {
      * @param amount Health amount the pearl health is reduced by
      */
     public PearlDecayEvent(ExilePearl pearl, int amount) {
+        this(pearl, amount, false);
+    }
+
+    /**
+     * Creates a new PearlDecayEvent instance.
+     *
+     * @param pearl   Pearl to decay
+     * @param amount  Health amount the pearl health is reduced by
+     * @param preview true when fired only to compute the effective decay amount (e.g. for lore),
+     *                without any health actually being removed. Listeners that apply side effects
+     *                (logging, metrics) should skip preview events; modifiers may still adjust the amount.
+     */
+    public PearlDecayEvent(ExilePearl pearl, int amount, boolean preview) {
         Preconditions.checkNotNull(pearl, "pearl");
         this.pearl = pearl;
         this.amount = amount;
+        this.preview = preview;
+    }
+
+    /**
+     * @return true when this event is a dry-run to compute the effective decay amount, not a real decay
+     */
+    public boolean isPreview() {
+        return preview;
     }
 
     /**

--- a/plugins/exilepearl-paper/src/test/java/com/devotedmc/ExilePearl/core/CoreLoreGeneratorTest.java
+++ b/plugins/exilepearl-paper/src/test/java/com/devotedmc/ExilePearl/core/CoreLoreGeneratorTest.java
@@ -21,6 +21,7 @@ class CoreLoreGeneratorTest {
     private PearlConfig config;
     private ExilePearl pearl;
     private CoreLoreGenerator generator;
+    private ExilePearlApi api;
     private MockedStatic<ExilePearlPlugin> pluginStatic;
 
     @BeforeEach
@@ -47,8 +48,9 @@ class CoreLoreGeneratorTest {
         Mockito.when(pearl.isActive()).thenReturn(true);
         Mockito.when(pearl.getLongTimeMultiplier()).thenReturn(1.0);
 
-        ExilePearlApi api = Mockito.mock(ExilePearlApi.class);
+        api = Mockito.mock(ExilePearlApi.class);
         Mockito.when(api.isBanStickEnabled()).thenReturn(false);
+        Mockito.when(api.getEffectivePearlDecayAmount(Mockito.any())).thenReturn(1); // base, no streak multiplier
         pluginStatic = Mockito.mockStatic(ExilePearlPlugin.class);
         pluginStatic.when(ExilePearlPlugin::getApi).thenReturn(api);
 
@@ -86,9 +88,20 @@ class CoreLoreGeneratorTest {
 
     @Test
     void generateLore_omitsTimeRemainingWhenDecayDisabled() {
-        Mockito.when(config.getPearlHealthDecayAmount()).thenReturn(0);
+        Mockito.when(api.getEffectivePearlDecayAmount(Mockito.any())).thenReturn(0);
         List<String> lore = generator.generateLore(pearl);
         Assertions.assertNull(findLine(lore, "Time remaining:"), "Decay disabled should hide time remaining; got: " + lore);
+    }
+
+    @Test
+    void generateLore_timeRemainingReflectsStreakMultiplier() {
+        // EssenceGlue doubles decay for a streaked player: 24/day -> 48/day, so 240 health = 5 days, not 10
+        Mockito.when(api.getEffectivePearlDecayAmount(Mockito.any())).thenReturn(2);
+        List<String> lore = generator.generateLore(pearl);
+        String timeRemaining = findLine(lore, "Time remaining:");
+        Assertions.assertNotNull(timeRemaining);
+        Assertions.assertTrue(timeRemaining.contains("5"),
+            "Doubled decay should halve time remaining (240/48 = 5 days), got: " + timeRemaining);
     }
 
     @Test


### PR DESCRIPTION
## What

Prison pearl tooltips lied about how long a pearl would last. The "Time remaining" and "Cost per X" lines were computed from the base decay amount in config, but EssenceGlue speeds decay up by the prisoner's vote streak (`1 + streak * 0.5`) via a `PearlDecayEvent` listener. A streaked prisoner's pearl drained much faster than the tag claimed. One freed in about 27 hours while reading "2 day", which matches the reports players kept filing.

## Fix

The lore now asks for the *effective* decay amount through a preview `PearlDecayEvent`, the same event the real decay loop fires. EssenceGlue (and any other modifier) adjusts that preview just like a real tick, so the displayed rate matches reality. ExilePearl stays unaware of EssenceGlue; the event is the seam.

- `PearlDecayEvent` gets a `preview` flag so side-effecting listeners (logging, metrics) can skip dry runs, while modifiers still adjust the amount.
- `ExilePearlApi.getEffectivePearlDecayAmount(pearl)` fires the preview and reads the result back.
- `CoreLoreGenerator` uses the effective amount for both the time and cost lines.

## Caveat

The streak drifts down as the prisoner stays offline, so the timer is a current estimate, not a fixed countdown. That's the honest best we can show without predicting future logins.

## Testing

`CoreLoreGeneratorTest` passes (9 tests, 0 failures), including a new case asserting a 2x streak multiplier halves the shown time (240 health at 48/day reads 5 days, not 10). Run locally via `./gradlew :plugins:exilepearl-paper:test --tests "com.devotedmc.ExilePearl.core.CoreLoreGeneratorTest"`.