### PR TITLE
Destination fixes

### DIFF
--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/DestinationScoreboard.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/DestinationScoreboard.java
@@ -13,9 +13,9 @@ public final class DestinationScoreboard {
     private static final String BOARD_KEY = "railSwitchDest";
 
     // CivScoreBoard truncates the displayed line at 40 chars but caches the full string,
-    // so an over-long line leaves a stale entry that never clears. The "/dest: " label plus
-    // colour codes is 11 chars, leaving 29 for the value.
-    private static final int MAX_DESTINATION_LENGTH = 29;
+    // so an over-long line leaves a stale entry that never clears. The "Dest: " label plus
+    // colour codes is 10 chars, leaving 30 for the value.
+    private static final int MAX_DESTINATION_LENGTH = 30;
 
     private final CivScoreBoard board;
 
@@ -49,6 +49,6 @@ public final class DestinationScoreboard {
         String value = destination.length() > MAX_DESTINATION_LENGTH
             ? destination.substring(0, MAX_DESTINATION_LENGTH)
             : destination;
-        return ChatColor.GOLD + "/dest: " + ChatColor.LIGHT_PURPLE + value;
+        return ChatColor.GOLD + "Dest: " + ChatColor.LIGHT_PURPLE + value;
     }
 }

--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/ResetSetting.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/settings/ResetSetting.java
@@ -17,7 +17,7 @@ public final class ResetSetting extends StringSetting {
     private final DestinationSetting destinationSetting;
 
     public ResetSetting(JavaPlugin plugin, DestinationSetting destinationSetting) {
-        super(plugin, "", "Clear Destination", "dest", new ItemStack(Material.BARRIER), "Clears your destination.");
+        super(plugin, "", "Clear Destination", "clearDest", new ItemStack(Material.BARRIER), "Clears your destination.");
         this.destinationSetting = destinationSetting;
     }
 

--- a/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/switches/DestSignListener.java
+++ b/plugins/railswitch-paper/src/main/java/sh/okx/railswitch/switches/DestSignListener.java
@@ -9,6 +9,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
 import sh.okx.railswitch.settings.SettingsManager;
 
 public final class DestSignListener implements Listener {
@@ -20,6 +21,9 @@ public final class DestSignListener implements Listener {
 
         //detect if is a dest sign
         if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+        if (event.getHand() != EquipmentSlot.HAND) {
             return;
         }
         Player player = event.getPlayer();

--- a/plugins/railswitch-paper/src/test/java/sh/okx/railswitch/settings/DestinationScoreboardTest.java
+++ b/plugins/railswitch-paper/src/test/java/sh/okx/railswitch/settings/DestinationScoreboardTest.java
@@ -25,13 +25,13 @@ class DestinationScoreboardTest {
 
     @Test
     void render_value_returnsLabelledColouredLine() {
-        String expected = ChatColor.GOLD + "/dest: " + ChatColor.LIGHT_PURPLE + "Spawn";
+        String expected = ChatColor.GOLD + "Dest: " + ChatColor.LIGHT_PURPLE + "Spawn";
         assertEquals(expected, DestinationScoreboard.render("Spawn"));
     }
 
     @Test
     void render_longValue_isCappedToFitScoreboardLine() {
         String line = DestinationScoreboard.render("A".repeat(60));
-        assertEquals(ChatColor.GOLD + "/dest: " + ChatColor.LIGHT_PURPLE + "A".repeat(29), line);
+        assertEquals(ChatColor.GOLD + "Dest: " + ChatColor.LIGHT_PURPLE + "A".repeat(30), line);
     }
 }


### PR DESCRIPTION
When the server restarts some players always have the same destination set even though they never selected that destination, thats because DestinationSetting and ResetSetting share the same key, when joining both have the same value, when changing the destination the DestinationSetting's value changes but the ResetSetting doesnt. When leaving both get saved and the ResetSetting overwrites the DestinationSetting resulting in the same value being saved for eternity.


Also changed the wording in the sidebar aswell as right clicking destination signs firing twice when an item is in the offhand.