### PR TITLE
ItemExchange: support multiple inputs and outputs per exchange

### DIFF
--- a/plugins/itemexchange-paper/README.md
+++ b/plugins/itemexchange-paper/README.md
@@ -29,8 +29,22 @@ An exchange rule shows (almost) all of its information in its tooltip. To increa
 is used in place of the Bukkit material name and durability value, wherever possible.
 
 A single exchange rule is either an input rule, defining items that the shop accepts, or an output rule, defining items
-that the shop gives in return. A single exchange consists of one input rule and one output rule. These are paired by the
-order that they're held in the shop's inventory; the first input rule is matched to the first output rule and so on.
+that the shop gives in return. An exchange consists of one or more input rules followed by one or more output rules.
+These are grouped by the order that they're held in the shop's inventory: an unbroken run of input rules, followed by an
+unbroken run of output rules, forms a single exchange. The next input rule after an output rule begins the next
+exchange.
+
+This means the familiar input/output/input/output layout behaves exactly as it always has — the first input pairs with
+the first output, the second with the second, and so on. Placing several inputs in a row before the outputs creates an
+exchange that costs several different items at once, and placing several outputs in a row makes an exchange that pays
+out several different items at once.
+
+For example, a chest holding an input for 2 iron, an input for 1 diamond, an output for 1 sword, and an output for 1
+shield, in that order, is a single exchange: it takes 2 iron *and* 1 diamond together, and gives back a sword *and* a
+shield together. A buyer must have every input, and the shop must hold every output, or the exchange won't go through —
+nothing is ever partially traded.
+
+To trigger the exchange, punch the shop while holding any one of its inputs; the rest are taken from your inventory.
 
 ![Image showing an input exchange rule tooltip in a shop inventory.](http://i.imgur.com/rC77hfy.png)
 ![Image showing an output exchange rule tooltip in a shop inventory.](http://i.imgur.com/hPzVh9n.png)
@@ -139,15 +153,40 @@ any number of exchanges while only using one inventory slot.
 The order of all exchange rules inside a bulk exchange rule is determined by how the components were placed on the
 crafting grid. When merging bulk exchange rules, one is essentially appended to the other.
 
-When forming input and output pairs, all exchange rules in the shop are considered, regardless of whether the rule is
-part of a bulk exchange rule or not. The first input rule is matched to the first output rule, the second to the second
-and so on, even if they are not in the same bulk exchange rule.
+When forming exchanges, all exchange rules in the shop are considered, regardless of whether the rule is part of a bulk
+exchange rule or not. Rules are grouped into exchanges purely by their order, even if they are not in the same bulk
+exchange rule.
 
 As an example of that, a chest containing only an input rule for 1 stone, and a bulk rule that contains an input rule
-for 1 wood and an output rule for 1 charcoal, in that order, will have an exchange selling charcoal for stone. The wood
-input rule cannot be matched to anything, and won't be a part of any exchange.
+for 1 wood and an output rule for 1 charcoal, in that order, will have a single exchange selling charcoal for 1 stone
+and 1 wood together, since the two input rules sit next to each other ahead of the output.
 
 When a bulk exchange rule is dropped onto the ground, it splits into its component exchange rules.
+
+## Exchange size limits
+
+Because a bulk exchange rule can hold any number of rules in a single item, it is cheap to build an exchange with a
+very large number of inputs or outputs. Server admins can cap this in `config.yml`:
+
+```yaml
+tradeLimits:
+  maxInputs: 8
+  maxOutputs: 8
+```
+
+`maxInputs` and `maxOutputs` limit how many rules a single exchange may have. An exchange that exceeds either limit is
+treated as broken and won't work at all. It is never quietly trimmed — dropping an input would let a buyer underpay,
+and dropping an output would shortchange them.
+
+Because the rule items in a container still look perfectly normal, and a bulk rule hides its contents entirely, a
+disabled exchange is called out when the shop is punched: *"1 exchange exceeds this server's size limit and has been
+disabled."* This is shown even if every exchange in the shop was disabled, in which case the container no longer
+functions as a shop at all.
+
+Every input and output of an exchange is always listed in full when browsing, so a buyer can always see the whole price
+before paying it.
+
+Set either of these to `0` for no limit. Changes take effect on **/iereload** (or **/ier**) — no restart needed.
 
 ## Redstone support
 

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeConfig.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeConfig.java
@@ -29,6 +29,10 @@ public final class ItemExchangeConfig extends ConfigParser {
     private static int RELAY_REACH_DISTANCE;
     private static final Set<Material> RELAY_PERMEABLE_BLOCKS = new HashSet<>();
     private static ShapelessRecipe BULK_RULE_RECIPE;
+    private static final int DEFAULT_MAX_TRADE_INPUTS = 8;
+    private static final int DEFAULT_MAX_TRADE_OUTPUTS = 8;
+    private static int MAX_TRADE_INPUTS = DEFAULT_MAX_TRADE_INPUTS;
+    private static int MAX_TRADE_OUTPUTS = DEFAULT_MAX_TRADE_OUTPUTS;
 
     public ItemExchangeConfig(final ItemExchangePlugin plugin) {
         super(plugin);
@@ -42,6 +46,7 @@ public final class ItemExchangeConfig extends ConfigParser {
         parseCreateFromShop(config.getBoolean("createShopFromChest", true));
         parseRepairableItems(config.getStringList("repairables"));
         parseShopRelay(config.getConfigurationSection("shopRelay"));
+        parseTradeLimits(config.getConfigurationSection("tradeLimits"));
         return true;
     }
 
@@ -55,10 +60,27 @@ public final class ItemExchangeConfig extends ConfigParser {
         RELAY_RECURSION_LIMIT = 0;
         RELAY_REACH_DISTANCE = 0;
         RELAY_PERMEABLE_BLOCKS.clear();
+        MAX_TRADE_INPUTS = DEFAULT_MAX_TRADE_INPUTS;
+        MAX_TRADE_OUTPUTS = DEFAULT_MAX_TRADE_OUTPUTS;
         if (BULK_RULE_RECIPE != null) {
             RecipeManager.removeRecipe(BULK_RULE_RECIPE);
             BULK_RULE_RECIPE = null;
         }
+    }
+
+    private void parseTradeLimits(final ConfigurationSection config) {
+        if (config == null) {
+            LOGGER.info("No trade limits configured; using defaults.");
+            return;
+        }
+        MAX_TRADE_INPUTS = Math.max(config.getInt("maxInputs", DEFAULT_MAX_TRADE_INPUTS), 0);
+        LOGGER.info(MAX_TRADE_INPUTS > 0
+            ? "Max trade inputs parsed: " + MAX_TRADE_INPUTS
+            : "Max trade inputs unlimited.");
+        MAX_TRADE_OUTPUTS = Math.max(config.getInt("maxOutputs", DEFAULT_MAX_TRADE_OUTPUTS), 0);
+        LOGGER.info(MAX_TRADE_OUTPUTS > 0
+            ? "Max trade outputs parsed: " + MAX_TRADE_OUTPUTS
+            : "Max trade outputs unlimited.");
     }
 
     private void parseShopCompatibleBlocks(final List<String> config) {
@@ -269,6 +291,20 @@ public final class ItemExchangeConfig extends ConfigParser {
 
     public static boolean hasRelayCompatibleBlock(Material material) {
         return RELAY_COMPATIBLE_BLOCKS.contains(material);
+    }
+
+    /**
+     * @return The most input rules a single trade may have, or zero if unlimited.
+     */
+    public static int getMaxTradeInputs() {
+        return MAX_TRADE_INPUTS;
+    }
+
+    /**
+     * @return The most output rules a single trade may have, or zero if unlimited.
+     */
+    public static int getMaxTradeOutputs() {
+        return MAX_TRADE_OUTPUTS;
     }
 
     public static int getRelayRecursionLimit() {

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeListener.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/ItemExchangeListener.java
@@ -95,6 +95,11 @@ public final class ItemExchangeListener implements Listener {
         // Attempt to parse a shop from the shop block or relays.
         ShopRule shop = ShopRule.resolveShop(clicked);
         if (!Validation.checkValidity(shop)) {
+            // A shop whose every exchange was disabled for being oversized isn't a valid shop, so say so rather
+            // than leaving the owner with a container that silently does nothing.
+            if (shop != null && shop.hasOversizedTrades()) {
+                shop.warnAboutOversizedTrades(player);
+            }
             PLUGIN.debug("[Shop] Cancelling, that is not a shop.");
             return;
         }
@@ -137,8 +142,6 @@ public final class ItemExchangeListener implements Listener {
             return;
         }
         PLUGIN.debug("[Shop] Valid trade found.");
-        ExchangeRule inputRule = trade.getInput();
-        ExchangeRule outputRule = trade.getOutput();
         // Check if the input is limited to a group, and if so whether the viewer
         // has permission to purchase from that group. If NameLayer is enabled.
         BrowseOrPurchaseEvent limitTester = BrowseOrPurchaseEvent.emit(shop, trade, player);
@@ -147,8 +150,8 @@ public final class ItemExchangeListener implements Listener {
             PLUGIN.debug("[Shop] Buyer cannot purchase from that Group limited trade. Browsing.");
         }
         // If the player's hand is empty or holding the wrong item, just scroll
-        // through the catalogue.
-        if (justBrowsing || !inputRule.conforms(event.getItem())) {
+        // through the catalogue. The held item need only match one of the inputs.
+        if (justBrowsing || trade.getInputs().stream().noneMatch((rule) -> rule.conforms(event.getItem()))) {
             if (shouldCycle) {
                 trade = shop.cycleTrades(!player.isSneaking());
                 if (trade == null) {
@@ -164,17 +167,17 @@ public final class ItemExchangeListener implements Listener {
             return;
         }
         PLUGIN.debug("[Shop] Attempting transaction.");
-        // Check that the buyer has enough of the inputs
-        ItemStack[] inputItems = inputRule.getStock(player.getInventory());
+        // Check that the buyer has enough of every input
+        ItemStack[] inputItems = Utilities.getStock(trade.getInputs(), player.getInventory());
         if (inputItems.length < 1) {
             PLUGIN.debug("[Shop] Cancelling, buyer doesn't have enough of the input.");
             player.sendMessage(ChatColor.RED + "You don't have enough of the input.");
             return;
         }
-        // Check that the shop has enough of the outputs if needed
+        // Check that the shop has enough of every output if needed
         ItemStack[] outputItems = new ItemStack[0];
-        if (trade.hasOutput()) {
-            outputItems = outputRule.getStock(trade.getInventory());
+        if (trade.hasOutputs()) {
+            outputItems = Utilities.getStock(trade.getOutputs(), trade.getInventory());
             if (outputItems.length < 1) {
                 PLUGIN.debug("[Shop] Cancelling, shop doesn't have enough of the output.");
                 player.sendMessage(ChatColor.RED + "Shop does not have enough in stock.");
@@ -183,7 +186,7 @@ public final class ItemExchangeListener implements Listener {
         }
         // Attempt to transfer the items between the shop and the buyer
         boolean successfulTransfer;
-        if (trade.hasOutput()) {
+        if (trade.hasOutputs()) {
             successfulTransfer = InventoryUtils.safelyTradeBetweenInventories(
                 player.getInventory(),
                 trade.getInventory(),
@@ -202,7 +205,7 @@ public final class ItemExchangeListener implements Listener {
         }
         Stream.of(clicked, trade.getBlock()).distinct().forEach(Utilities::successfulTransactionButton);
         SuccessfulPurchaseEvent.emit(player, trade, inputItems, outputItems);
-        if (trade.hasOutput()) {
+        if (trade.hasOutputs()) {
             player.sendMessage(ChatColor.GREEN + "Successful exchange!");
         } else {
             player.sendMessage(ChatColor.GREEN + "Successful donation!");

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/glues/namelayer/NameLayerGlue.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/glues/namelayer/NameLayerGlue.java
@@ -22,13 +22,17 @@ public final class NameLayerGlue extends DependencyGlue {
     private final Listener listener = new Listener() {
         @EventHandler(ignoreCancelled = true)
         public void denyPurchaseIfNotGotPerms(final BrowseOrPurchaseEvent event) {
-            final GroupModifier modifier = event.getTrade().getInput().getModifiers().get(GroupModifier.class);
-            if (!Validation.checkValidity(modifier)
-                || PermissionsGlue.PURCHASE_PERMISSION.testPermission(
-                GroupManager.getGroup(modifier.getGroupId()), event.getBrowser())) {
+            // A group restriction on any of the trade's inputs restricts the whole trade.
+            for (final var input : event.getTrade().getInputs()) {
+                final GroupModifier modifier = input.getModifiers().get(GroupModifier.class);
+                if (!Validation.checkValidity(modifier)
+                    || PermissionsGlue.PURCHASE_PERMISSION.testPermission(
+                    GroupManager.getGroup(modifier.getGroupId()), event.getBrowser())) {
+                    continue;
+                }
+                event.limitToBrowsing();
                 return;
             }
-            event.limitToBrowsing();
         }
     };
 

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/ShopRule.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/ShopRule.java
@@ -33,6 +33,8 @@ public final class ShopRule implements Validation {
 
     private int currentTradeIndex;
 
+    private int oversizedTrades;
+
     @Override
     public boolean isValid() {
         if (CollectionUtils.isEmpty(this.trades)) {
@@ -66,6 +68,27 @@ public final class ShopRule implements Validation {
         return this.trades.get(this.currentTradeIndex);
     }
 
+    /**
+     * @return Returns true if any of this shop's exchanges were disabled for exceeding the configured size limits.
+     */
+    public boolean hasOversizedTrades() {
+        return this.oversizedTrades > 0;
+    }
+
+    /**
+     * Tells a player that some of this shop's exchanges have been disabled for being too large. Without this the shop
+     * would fail silently: an oversized exchange never enters the catalogue, so there's no gap in the listing to
+     * notice, and the rule items in the container still look perfectly normal.
+     */
+    public void warnAboutOversizedTrades(Player player) {
+        if (this.oversizedTrades < 1) {
+            return;
+        }
+        player.sendMessage(ChatColor.RED + (this.oversizedTrades == 1
+            ? "1 exchange exceeds this server's size limit and has been disabled."
+            : this.oversizedTrades + " exchanges exceed this server's size limit and have been disabled."));
+    }
+
     public TradeRule cycleTrades(boolean forward) {
         if (this.trades.isEmpty()) {
             return null;
@@ -86,17 +109,22 @@ public final class ShopRule implements Validation {
         }
         player.sendMessage(String.format("%s(%d/%d) exchanges present.",
             ChatColor.YELLOW, this.currentTradeIndex + 1, this.trades.size()));
-        for (String line : trade.getInput().getDisplayInfo()) {
-            player.sendMessage(line);
-        }
-        if (trade.getOutput() != null) {
-            for (String line : trade.getOutput().getDisplayInfo()) {
+        for (ExchangeRule input : trade.getInputs()) {
+            for (String line : input.getDisplayInfo()) {
                 player.sendMessage(line);
+            }
+        }
+        if (trade.hasOutputs()) {
+            for (ExchangeRule output : trade.getOutputs()) {
+                for (String line : output.getDisplayInfo()) {
+                    player.sendMessage(line);
+                }
             }
             PLUGIN.debug("[ShopRule] Calculating stock.");
             int stock = trade.calculateStock();
             player.sendMessage(ChatColor.YELLOW + "" + stock + " exchange" + (stock == 1 ? "" : "s") + " available.");
         }
+        warnAboutOversizedTrades(player);
     }
 
     // ------------------------------------------------------------
@@ -171,41 +199,52 @@ public final class ShopRule implements Validation {
         return found;
     }
 
+    /**
+     * Finishes off a gathered trade, keeping it if it's usable and otherwise noting why it was thrown away.
+     */
+    private void completeTrade(List<TradeRule> trades, TradeRule trade) {
+        if (trade.isValid()) {
+            trades.add(trade);
+        } else if (trade.isOversized()) {
+            this.oversizedTrades++;
+            PLUGIN.debug("[Resolve] Discarding oversized trade.");
+        }
+    }
+
+    /**
+     * Groups a shop's rules into trades. A trade is an unbroken run of input rules followed by an unbroken run of
+     * output rules, so an input that follows an output begins the next trade. This keeps the classic
+     * one-input-to-one-output layout working exactly as it always has, while allowing a trade to ask for several
+     * inputs and to pay out several outputs.
+     */
     private List<TradeRule> extractTradesFromInventory(Inventory inventory) {
         List<TradeRule> trades = Lists.newArrayList();
         List<ExchangeRule> rules = extractRulesFromInventory(inventory);
-        Type previousType = null;
         TradeRule currentTrade = new TradeRule(inventory);
-        // TODO: Future me should git gud and make this better and more readable... like seriously!
         for (ExchangeRule rule : rules) {
+            // A broken rule severs whatever trade was being gathered.
             if (rule == null || rule.isBroken()) {
-                previousType = null;
+                completeTrade(trades, currentTrade);
+                currentTrade = new TradeRule(inventory);
                 continue;
             }
             Type type = rule.getType();
             if (type == Type.INPUT) {
-                if (previousType != null) {
-                    if (currentTrade.isValid()) {
-                        trades.add(currentTrade);
-                        currentTrade = new TradeRule(inventory);
-                    }
-                } else {
+                // An input that follows an output starts the next trade.
+                if (currentTrade.hasOutputs()) {
+                    completeTrade(trades, currentTrade);
                     currentTrade = new TradeRule(inventory);
                 }
-                currentTrade.setInput(rule);
-                previousType = Type.INPUT;
+                currentTrade.addInput(rule);
             } else if (type == Type.OUTPUT) {
-                if (previousType != Type.INPUT) {
-                    previousType = Type.OUTPUT;
+                // An output with no preceding input has nothing to attach itself to.
+                if (currentTrade.getInputs().isEmpty()) {
                     continue;
                 }
-                currentTrade.setOutput(rule);
-                previousType = Type.OUTPUT;
+                currentTrade.addOutput(rule);
             }
         }
-        if (currentTrade.isValid()) {
-            trades.add(currentTrade);
-        }
+        completeTrade(trades, currentTrade);
         return trades;
     }
 

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/TradeRule.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/rules/TradeRule.java
@@ -1,7 +1,13 @@
 package com.untamedears.itemexchange.rules;
 
+import com.untamedears.itemexchange.ItemExchangeConfig;
 import com.untamedears.itemexchange.rules.ExchangeRule.Type;
+import com.untamedears.itemexchange.utility.Utilities;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import org.apache.commons.collections4.CollectionUtils;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.Inventory;
 import vg.civcraft.mc.civmodcore.inventory.InventoryUtils;
@@ -9,13 +15,13 @@ import vg.civcraft.mc.civmodcore.utilities.Validation;
 import vg.civcraft.mc.civmodcore.world.WorldUtils;
 
 /**
- * This class represents a specific trade within a shop, an input and output pair, or a donation.
+ * This class represents a specific trade within a shop, a set of inputs and outputs, or a donation.
  */
 public final class TradeRule implements Validation {
 
-    private ExchangeRule input;
+    private final List<ExchangeRule> inputs = new ArrayList<>();
 
-    private ExchangeRule output;
+    private final List<ExchangeRule> outputs = new ArrayList<>();
 
     private Inventory inventory;
 
@@ -25,20 +31,19 @@ public final class TradeRule implements Validation {
 
     @Override
     public boolean isValid() {
-        if (this.input == null) {
+        if (CollectionUtils.isEmpty(this.inputs)) {
             return false;
         }
-        if (this.input.isBroken()) {
+        if (isOversized()) {
             return false;
         }
-        if (this.input.getType() != Type.INPUT) {
-            return false;
-        }
-        if (this.output != null) {
-            if (this.output.isBroken()) {
+        for (ExchangeRule input : this.inputs) {
+            if (input == null || input.isBroken() || input.getType() != Type.INPUT) {
                 return false;
             }
-            if (this.output.getType() != Type.OUTPUT) {
+        }
+        for (ExchangeRule output : this.outputs) {
+            if (output == null || output.isBroken() || output.getType() != Type.OUTPUT) {
                 return false;
             }
         }
@@ -52,57 +57,124 @@ public final class TradeRule implements Validation {
     }
 
     /**
+     * Checks whether this trade has more inputs or outputs than the server allows. An oversized trade is rejected
+     * outright rather than trimmed: dropping an input would let the buyer underpay, and dropping an output would
+     * shortchange them.
+     *
+     * @return Returns true if this trade exceeds the configured limits.
+     */
+    public boolean isOversized() {
+        final int maxInputs = ItemExchangeConfig.getMaxTradeInputs();
+        if (maxInputs > 0 && this.inputs.size() > maxInputs) {
+            return true;
+        }
+        final int maxOutputs = ItemExchangeConfig.getMaxTradeOutputs();
+        if (maxOutputs > 0 && this.outputs.size() > maxOutputs) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Determines how many times this rule matches with the given inventory.
      *
      * @return The number of trades that can be performed.
      */
     public int calculateStock() {
-        return output.calculateStock(this.inventory);
+        return Utilities.calculateStock(this.outputs, this.inventory);
     }
 
     /**
-     * Gets the trade's input rule.
+     * Gets the trade's input rules.
      *
-     * @return The trade's input rule.
+     * @return The trade's input rules, of which there will always be at least one for a valid trade.
+     */
+    public List<ExchangeRule> getInputs() {
+        return Collections.unmodifiableList(this.inputs);
+    }
+
+    /**
+     * Adds an input rule to the trade.
+     *
+     * @param input The input rule to add.
+     */
+    public void addInput(ExchangeRule input) {
+        this.inputs.add(input);
+    }
+
+    /**
+     * Gets the trade's first input rule.
+     *
+     * @return The trade's first input rule, or null if it has none.
+     * @apiNote Prefer {@link TradeRule#getInputs()}, as a trade may have several inputs.
      */
     public ExchangeRule getInput() {
-        return this.input;
+        return this.inputs.isEmpty() ? null : this.inputs.get(0);
     }
 
     /**
-     * Sets the trade's input rule.
+     * Sets the trade's inputs to the single given rule.
      *
      * @param input The input rule to set.
      */
     public void setInput(ExchangeRule input) {
-        this.input = input;
+        this.inputs.clear();
+        this.inputs.add(input);
     }
 
     /**
-     * Checks whether the trade has an output.
+     * Checks whether the trade has any outputs, which is to say whether it's an exchange rather than a donation.
      *
-     * @return Returns true if the trade has an output rule.
+     * @return Returns true if the trade has at least one output rule.
+     */
+    public boolean hasOutputs() {
+        return !this.outputs.isEmpty();
+    }
+
+    /**
+     * @return Returns true if the trade has at least one output rule.
+     * @apiNote Prefer {@link TradeRule#hasOutputs()}.
      */
     public boolean hasOutput() {
-        return this.output != null;
+        return hasOutputs();
     }
 
     /**
-     * Gets the trade's output rule.
+     * Gets the trade's output rules.
      *
-     * @return The trade's output rule.
+     * @return The trade's output rules, which will be empty if the trade is a donation.
+     */
+    public List<ExchangeRule> getOutputs() {
+        return Collections.unmodifiableList(this.outputs);
+    }
+
+    /**
+     * Adds an output rule to the trade.
+     *
+     * @param output The output rule to add.
+     */
+    public void addOutput(ExchangeRule output) {
+        this.outputs.add(output);
+    }
+
+    /**
+     * Gets the trade's first output rule.
+     *
+     * @return The trade's first output rule, or null if it has none.
+     * @apiNote Prefer {@link TradeRule#getOutputs()}, as a trade may have several outputs.
      */
     public ExchangeRule getOutput() {
-        return this.output;
+        return this.outputs.isEmpty() ? null : this.outputs.get(0);
     }
 
     /**
-     * Sets the trade's output rule.
+     * Sets the trade's outputs to the single given rule.
      *
      * @param output The output rule to set.
      */
     public void setOutput(ExchangeRule output) {
-        this.output = output;
+        this.outputs.clear();
+        this.outputs.add(output);
     }
 
     public Inventory getInventory() {

--- a/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/Utilities.java
+++ b/plugins/itemexchange-paper/src/main/java/com/untamedears/itemexchange/utility/Utilities.java
@@ -6,7 +6,9 @@ import com.untamedears.itemexchange.ItemExchangeConfig;
 import com.untamedears.itemexchange.ItemExchangePlugin;
 import com.untamedears.itemexchange.rules.BulkExchangeRule;
 import com.untamedears.itemexchange.rules.ExchangeRule;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -28,6 +30,7 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionType;
 import org.jetbrains.annotations.NotNull;
 import vg.civcraft.mc.civmodcore.inventory.InventoryUtils;
+import vg.civcraft.mc.civmodcore.inventory.items.ItemUtils;
 import vg.civcraft.mc.civmodcore.utilities.KeyedUtils;
 import vg.civcraft.mc.civmodcore.utilities.NullUtils;
 import vg.civcraft.mc.civmodcore.world.WorldUtils;
@@ -164,6 +167,134 @@ public final class Utilities {
                     }, 30L);
                 }
             });
+    }
+
+    // ------------------------------------------------------------
+    // Stock
+    // ------------------------------------------------------------
+
+    /**
+     * A snapshot of which of an inventory's items each of a set of rules will accept. Conformance is worked out once
+     * up front because testing it is not cheap, which then allows the reservation below to be run repeatedly for next
+     * to nothing.
+     */
+    private record StockSnapshot(ItemStack[] contents, int[] amounts, List<ExchangeRule> rules,
+                                 boolean[][] conformance) {
+
+        private static StockSnapshot of(final Collection<ExchangeRule> rules, final Inventory inventory) {
+            if (CollectionUtils.isEmpty(rules) || !InventoryUtils.isValidInventory(inventory)) {
+                return null;
+            }
+            final ItemStack[] contents = inventory.getStorageContents();
+            final int[] amounts = new int[contents.length];
+            for (int slot = 0; slot < contents.length; slot++) {
+                final ItemStack item = contents[slot];
+                amounts[slot] = !ItemUtils.isValidItem(item) || isExchangeRule(item) ? 0 : item.getAmount();
+            }
+            final var ruleList = new ArrayList<>(rules);
+            final var conformance = new boolean[ruleList.size()][contents.length];
+            for (int index = 0; index < ruleList.size(); index++) {
+                final ExchangeRule rule = ruleList.get(index);
+                if (rule == null) {
+                    return null;
+                }
+                for (int slot = 0; slot < contents.length; slot++) {
+                    conformance[index][slot] = amounts[slot] > 0 && rule.conforms(contents[slot]);
+                }
+            }
+            return new StockSnapshot(contents, amounts, ruleList, conformance);
+        }
+
+        /**
+         * Greedily reserves the items needed to satisfy every rule a set number of times over. Rules are served in
+         * order and no item is ever claimed twice, so two rules that happen to match the same items will each be
+         * given their own share rather than both laying claim to the same stack.
+         *
+         * @param multiplier How many times over the rules must be satisfied.
+         * @param claimed    Collects the reserved items, or null to only test satisfiability.
+         * @return Returns true if every rule was fully satisfied.
+         */
+        private boolean reserve(final int multiplier, final Collection<ItemStack> claimed) {
+            if (multiplier < 1) {
+                return false;
+            }
+            // Tracks how much of each slot is still up for grabs.
+            final int[] remaining = this.amounts.clone();
+            for (int index = 0; index < this.rules.size(); index++) {
+                long required = (long) this.rules.get(index).getAmount() * multiplier;
+                final boolean[] conforms = this.conformance[index];
+                for (int slot = 0; slot < remaining.length && required > 0L; slot++) {
+                    if (remaining[slot] <= 0 || !conforms[slot]) {
+                        continue;
+                    }
+                    final int taken = (int) Math.min(remaining[slot], required);
+                    remaining[slot] -= taken;
+                    required -= taken;
+                    if (claimed != null) {
+                        final ItemStack clone = this.contents[slot].clone();
+                        clone.setAmount(taken);
+                        claimed.add(clone);
+                    }
+                }
+                if (required > 0L) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    /**
+     * Determines the stock items themselves from a given inventory, which can then be used for trade purposes.
+     *
+     * @param rules     The rules that must all be satisfied.
+     * @param inventory The inventory to determine the stock within.
+     * @return An array of cloned items that can then be used within trade APIs, which will be empty if the given
+     * inventory cannot satisfy every rule at once.
+     */
+    public static ItemStack[] getStock(final Collection<ExchangeRule> rules, final Inventory inventory) {
+        final StockSnapshot snapshot = StockSnapshot.of(rules, inventory);
+        if (snapshot == null) {
+            return new ItemStack[0];
+        }
+        final var claimed = new ArrayList<ItemStack>();
+        if (!snapshot.reserve(1, claimed)) {
+            return new ItemStack[0];
+        }
+        return claimed.toArray(new ItemStack[0]);
+    }
+
+    /**
+     * Determines how many times the given rules can all be satisfied by the given inventory at once.
+     *
+     * @param rules     The rules that must all be satisfied.
+     * @param inventory The inventory to determine the stock within.
+     * @return Returns the number of times the rules can be satisfied.
+     */
+    public static int calculateStock(final Collection<ExchangeRule> rules, final Inventory inventory) {
+        final StockSnapshot snapshot = StockSnapshot.of(rules, inventory);
+        if (snapshot == null || !snapshot.reserve(1, null)) {
+            return 0;
+        }
+        // Double until the rules can no longer be satisfied, then binary search the boundary.
+        int satisfiable = 1;
+        int excessive = 2;
+        while (snapshot.reserve(excessive, null)) {
+            satisfiable = excessive;
+            if (excessive > Integer.MAX_VALUE / 2) {
+                return satisfiable;
+            }
+            excessive *= 2;
+        }
+        while (excessive - satisfiable > 1) {
+            final int middle = satisfiable + ((excessive - satisfiable) / 2);
+            if (snapshot.reserve(middle, null)) {
+                satisfiable = middle;
+            } else {
+                excessive = middle;
+            }
+        }
+        return satisfiable;
     }
 
     // ------------------------------------------------------------

--- a/plugins/itemexchange-paper/src/main/resources/config.yml
+++ b/plugins/itemexchange-paper/src/main/resources/config.yml
@@ -24,6 +24,17 @@ ruleItem: "STONE_BUTTON"
 # Allows players to create a shop by looking at a valid shop block with an acceptable format of items
 createShopFromChest: true
 
+# Limits on how large a single exchange may be. An exchange is an unbroken run of input rules
+# followed by an unbroken run of output rules, so bulk rule blocks can make very large exchanges
+# cheap to build. Any exchange that exceeds these limits is treated as broken and will not work
+# at all; it is never quietly trimmed, since dropping an input would let a buyer underpay.
+# Set a value to 0 for no limit.
+tradeLimits:
+  # Maximum number of input rules a single exchange may require.
+  maxInputs: 8
+  # Maximum number of output rules a single exchange may pay out.
+  maxOutputs: 8
+
 repairables:
   - "NETHERITE_HELMET"
   - "NETHERITE_CHESTPLATE"


### PR DESCRIPTION
## Summary

An exchange could only ever pair one input rule with one output rule. A single exchange can now require several different items and pay out several — e.g. 2 iron + 1 diamond for a sword + a shield.

Rules are grouped by their order in the shop inventory: an unbroken run of inputs followed by an unbroken run of outputs is one exchange, and the next input after an output starts the next. Trades stay all-or-nothing — the buyer must have every input and the shop every output, or nothing moves. Every input and output is always listed when browsing, so a buyer always sees the full price before paying it.

##  Behaviour change

`input,output,input,output` — the documented and common layout — parses identically to before, so ordinary shops are unaffected.

Consecutive inputs now merge instead of splitting. `input,input,output,output` was previously a donation of the first input plus an exchange of the second input for the first output, with the second output ignored; it is now one exchange taking both inputs for both outputs.

This matters most for **donation shops**. A chest of 12 input rules with no outputs used to be 12 separate donations; it is now a single exchange demanding all 12 items at once — and past `maxInputs` it is disabled entirely.

## Why the new stock allocator

`Utilities.getStock` / `calculateStock` are load-bearing, not cosmetic. The old per-rule scan searched the inventory independently for each rule, so two rules matching the same items would both claim the same stack and the trade would silently under-charge. The new allocator reserves across all rules at once with no double-claiming.

Conformance is precomputed once per call because `ExchangeRule.conforms()` builds its debug strings unconditionally, and the stock search would otherwise multiply its call count on the browse path — which runs on every punch.

## Exchange size limits

A bulk rule block holds any number of rules in one item, so a very large exchange is cheap to build. New `config.yml` section, live-reloadable with `/iereload`:

```yaml
tradeLimits:
  maxInputs: 8
  maxOutputs: 8
```

An over-limit exchange is **rejected outright, never trimmed** — dropping an input would let a buyer underpay, and dropping an output would shortchange them. Enforcement is in `TradeRule.isValid()`, the one chokepoint both the grouping and the listener already gate on, and it sits after bulk flattening so loose and bulk rules are measured identically. The limit applies per exchange, not per bulk item: one bulk block can still hold any number of normal exchanges.

Because rule items look normal in a container and a bulk block hides its contents, a disabled exchange is announced on punch

`0` means no limit configs without a `tradeLimits` section fall back to the jar defaults

## Notes

- `TradeRule` now holds lists. `getInput()`, `getOutput()` and `hasOutput()` are retained
- `NameLayerGlue` now checks every input. It would have compiled unchanged, but a group lock on any non-first input would have been **silently bypassed**.
- Bulk rules are flattened in order before grouping, so they behave exactly like loose rules, including runs spanning two bulk blocks. Grouping never spans separate containers.
- No changes to the item transfer layer — `InventoryUtils` already accepted item arrays and committed atomically.

## Testing

Tested on a local Paper 1.21.8 server running the full plugin set, and it works:

- existing single-input → single-output shops behave exactly as before
- multi-input / multi-output exchanges take every input and pay out every output
- the exchange is refused when the buyer is short any input, or the shop is short any output
- donations (inputs with no outputs) work
- bulk rules behave the same as loose rules, including a run spanning a bulk block and a loose rule
- browsing lists every input and output with the correct stock count
- over-limit exchanges are disabled and reported to the player
---

# LLM use
Implementation and write-up assisted by Claude Opus 5.